### PR TITLE
Patched Goats Minigame and adjust readFile call for gci's generated with DVD params

### DIFF
--- a/GameCube/include/events.h
+++ b/GameCube/include/events.h
@@ -153,6 +153,7 @@ namespace mod::events
     uint16_t getPauseRupeeMax(libtp::tp::d_save::dSv_player_status_a_c* plyrStatus);
     uint32_t autoMashThroughText(libtp::tp::m_do_controller_pad::CPadInfo* padInfo);
     void* handleTransformAnywhere(libtp::tp::f_op_actor_iter::fopAcIt_JudgeFunc unk1, void* unk2);
+    bool checkValidTransformAnywhere();
 
     void performStaticASMReplacement(uint32_t memoryOffset, uint32_t value);
 

--- a/GameCube/subrel/boot/source/rando/seedlist.cpp
+++ b/GameCube/subrel/boot/source/rando/seedlist.cpp
@@ -123,7 +123,7 @@ namespace mod::rando
             snprintf(filePath, sizeof(filePath), "/mod/seed/%s", currentFileName);
 
             // Try to open the file and get the header data
-            if (DVD_STATE_END != libtp::tools::ReadFile(filePath, sizeof(header), 0, &header))
+            if (DVD_STATE_END != libtp::tools::readFile(filePath, sizeof(header), 0, &header))
             {
 #else
             // Try to get the status of an arbitrary file slot

--- a/GameCube/subrel/seed/source/rando/seed.cpp
+++ b/GameCube/subrel/seed/source/rando/seed.cpp
@@ -56,7 +56,7 @@ namespace mod::rando
         char filePath[96];
         snprintf(filePath, sizeof(filePath), "/mod/seed/%s", fileName);
 
-        m_CARDResult = libtp::tools::ReadFile(filePath, totalSize, 0, data);
+        m_CARDResult = libtp::tools::readFile(filePath, totalSize, 0, data);
         constexpr int32_t resultComparison = DVD_STATE_END;
 #else
         // The memory card should already be mounted


### PR DESCRIPTION
- Added a function that prevents the player from transforming during the Goat Herding minigame (even with transform anywhere enabled) as this causes a crash if you complete the minigame as wolf. 
- Changed the function call in the subrels from `ReadFile` to `readFile` to line up with the libtp naming convention and resolve compilation errors