### PR TITLE
Fix savewarp

### DIFF
--- a/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
+++ b/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
@@ -62,5 +62,23 @@ namespace mod::game_patch
                 playerReturnPlacePtr->link_room_id = 0x6;
             }
         }
+         else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::stageIDs::Fyrus]))
+        {
+            strncpy(playerReturnPlacePtr->link_current_stage,
+                    stagesPtr[stage::stageIDs::Goron_Mines],
+                    sizeof(playerReturnPlacePtr->link_current_stage) - 1);
+
+            playerReturnPlacePtr->link_spawn_point_id = 0x0;
+            playerReturnPlacePtr->link_room_id = 0x1;
+        }
+        else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::stageIDs::Argorok]))
+        {
+            strncpy(playerReturnPlacePtr->link_current_stage,
+                    stagesPtr[stage::stageIDs::City_in_the_Sky],
+                    sizeof(playerReturnPlacePtr->link_current_stage) - 1);
+
+            playerReturnPlacePtr->link_spawn_point_id = 0x0;
+            playerReturnPlacePtr->link_room_id = 0x0;
+        }
     }
 } // namespace mod::game_patch


### PR DESCRIPTION
Fix savewarp for argorok and fyrus and now return to the entrance of the dungeon instead of the boss area