### PR TITLE
Ice Trap damage multiplier and Ammo changes

### DIFF
--- a/GameCube/source/game_patch/04_verifyItemFunctions.cpp
+++ b/GameCube/source/game_patch/04_verifyItemFunctions.cpp
@@ -209,7 +209,7 @@ namespace mod::game_patch
                 case Clawshot:
                 case Double_Clawshots:
                 {
-                   if ( events::haveItem( Clawshot ) || events::haveItem( Double_Clawshots ) )
+                    if (events::haveItem(Clawshot) || events::haveItem(Double_Clawshots))
                     {
                         itemID = Double_Clawshots;
                     }
@@ -311,6 +311,49 @@ namespace mod::game_patch
                     }
 
                     foolishItemsPtr->spawnCount = static_cast<uint8_t>(count);
+                    break;
+                }
+
+                // For ammo, if we don't have the item that can use the ammo, turn it into a blue rupee so that the check
+                // doesn't completely go to waste.
+                case Arrows_10:
+                case Arrows_20:
+                case Arrows_30:
+                {
+                    if (!events::haveItem(Heros_Bow))
+                    {
+                        itemID = Blue_Rupee;
+                    }
+                    break;
+                }
+
+                case Bombling_1:
+                case Bomblings_10:
+                case Bomblings_3:
+                case Bomblings_5:
+                case Water_Bombs_10:
+                case Water_Bombs_15:
+                case Water_Bombs_3:
+                case Water_Bombs_5:
+                case Bombs_10:
+                case Bombs_20:
+                case Bombs_30:
+                case Bombs_5:
+                {
+                    if (!events::haveItem(Goron_Bomb_Bag)) // This is the specific bomb bag that the rando uses when giving
+                                                           // bombs to the player.
+                    {
+                        itemID = Blue_Rupee;
+                    }
+                    break;
+                }
+
+                case Seeds_50:
+                {
+                    if (!events::haveItem(Slingshot))
+                    {
+                        itemID = Blue_Rupee;
+                    }
                     break;
                 }
 

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1850,12 +1850,12 @@ namespace mod
 
         if (playerStatusPtr->currentForm == 1)
         {
-            newHealthValue = playerStatusPtr->currentHealth - (2 * count);
+            newHealthValue = playerStatusPtr->currentHealth - (2 * count * damageMultiplier);
             d_a_alink::procWolfDamageInit(linkMapPtr, nullptr);
         }
         else
         {
-            newHealthValue = playerStatusPtr->currentHealth - count;
+            newHealthValue = playerStatusPtr->currentHealth - (count * damageMultiplier);
             d_a_alink::procDamageInit(linkMapPtr, nullptr, 0);
         }
 

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1850,7 +1850,7 @@ namespace mod
 
         if (playerStatusPtr->currentForm == 1)
         {
-            newHealthValue = playerStatusPtr->currentHealth - (2 * count * damageMultiplier);
+            newHealthValue = playerStatusPtr->currentHealth - ((2 * count) * damageMultiplier);
             d_a_alink::procWolfDamageInit(linkMapPtr, nullptr);
         }
         else


### PR DESCRIPTION
- Added the damage multiplier to be accounted for during the initial Ice Trap freeze as the player can avoid the multiplied damage if they mashed fast enough.
- Added conditions for ammo in the verifyProgressiveItem function so that if the randomizer is trying to give the player a form of ammo that they cannot use (i.e Arrows when the Player does not have a bow) the ammo will be replaced with a Blue Rupee