### PR TITLE
1.1

### DIFF
--- a/GameCube/Makefile
+++ b/GameCube/Makefile
@@ -14,8 +14,8 @@ export BUILDID:='"$(shell date +'%Y%m%d%H%M')"'
 
 # Version
 export _VERSION_MAJOR:=1
-export _VERSION_MINOR:=0
-export _VERSION_PATCH:=1
+export _VERSION_MINOR:=1
+export _VERSION_PATCH:=0
 export _VERSION:='"$(_VERSION_MAJOR).$(_VERSION_MINOR).$(_VERSION_PATCH)"'
 # Variant: i.e. Public, NoLogic, Race, etc.
 #export _VARIANT:= public

--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -338,6 +338,7 @@
 803ae280:item_resource
 803b0a58:item_info
 803afa68:field_item_res
+800993b4:item_func_ASHS_SCRIBBLING
 
 //processor.o
 802a8a54:getResource_groupID

--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -152,6 +152,12 @@
 80432164:wZButtonPtr
 8021e388:resetMiniGameItem
 
+//d_meter2_draw.o
+80215178:drawKanteraScreen
+
+//d_pane_class.o
+80254ee0:setBlackWhite
+
 // d_menu_collect.o
 801B3598:setWalletMaxNum
 801b09a4:dMenuCollect_screenSet

--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -139,6 +139,9 @@
 800b7f58:searchBouDoor
 800c0884:checkCastleTownUseItem
 800d7414:damageMagnification
+800c5120:procFrontRollCrashInit
+8012dacc:procWolfDashReverseInit
+8013cad4:procWolfAttackReverseInit
 
 // data
 8039038C:climbVars

--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -137,6 +137,7 @@
 80138ec4:setWolfLockDomeModel
 800d0434:getSpinnerActor
 800b7f58:searchBouDoor
+800d7414:damageMagnification
 
 // data
 8039038C:climbVars

--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -137,6 +137,7 @@
 80138ec4:setWolfLockDomeModel
 800d0434:getSpinnerActor
 800b7f58:searchBouDoor
+800c0884:checkCastleTownUseItem
 
 // data
 8039038C:climbVars

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -329,6 +329,7 @@
 803a7ee8:field_item_res
 803a92d8:item_func_ptr
 803a8ed8:item_info
+800992c4:item_func_ASHS_SCRIBBLING
 
 // d_menu_ring.o
 801eb424:dMenuRing__draw

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -139,6 +139,9 @@
 800b7d84:searchBouDoor
 800c06b0:checkCastleTownUseItem
 800d7240:damageMagnification
+800c4f4c:procFrontRollCrashInit
+8012d90c:procWolfDashReverseInit
+8013c914:procWolfAttackReverseInit
 
 // data
 80388C0C:climbVars

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -389,6 +389,12 @@
 8042a2c8:g_meter2_info
 8021e81c:resetMiniGameItem
 
+//d_meter2_draw.o
+80215584:drawKanteraScreen
+
+//d_pane_class.o
+802567d0:setBlackWhite
+
 // d_a_player.o
 8044b158:m_midnaActor
 

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -137,6 +137,7 @@
 80138d04:setWolfLockDomeModel
 800d0260:getSpinnerActor
 800b7d84:searchBouDoor
+800d7240:damageMagnification
 
 // data
 80388C0C:climbVars

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -137,6 +137,7 @@
 80138d04:setWolfLockDomeModel
 800d0260:getSpinnerActor
 800b7d84:searchBouDoor
+800c06b0:checkCastleTownUseItem
 
 // data
 80388C0C:climbVars

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -116,6 +116,7 @@
 803AC5A0:item_resource
 803ADD88:field_item_res
 803AED78:item_info
+80099284:item_func_ASHS_SCRIBBLING
 
 // d_a_alink.h
 800B271C:setStickData

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -147,6 +147,9 @@
 800b7d4c:searchBouDoor
 800c0678:checkCastleTownUseItem
 800d7208:damageMagnification
+800c4f14:procFrontRollCrashInit
+8012d8c0:procWolfDashReverseInit
+8013c8c8:procWolfAttackReverseInit
 
 // data
 8038EB8C:climbVars

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -145,6 +145,7 @@
 80138cb8:setWolfLockDomeModel
 800d0228:getSpinnerActor
 800b7d4c:searchBouDoor
+800c0678:checkCastleTownUseItem
 
 // data
 8038EB8C:climbVars

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -145,6 +145,7 @@
 80138cb8:setWolfLockDomeModel
 800d0228:getSpinnerActor
 800b7d4c:searchBouDoor
+800d7208:damageMagnification
 
 // data
 8038EB8C:climbVars

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -338,6 +338,12 @@
 804301A4:wZButtonPtr
 8021e0c4:resetMiniGameItem
 
+//d_meter2_draw.o
+80214eb4:drawKanteraScreen
+
+//d_pane_class.o
+80254458:setBlackWhite
+
 //d_a_shop_item_static.o
 803792e8:shopItemData
 

--- a/GameCube/include/events.h
+++ b/GameCube/include/events.h
@@ -21,6 +21,7 @@
 #include "tp/m_do_controller_pad.h"
 #include "tp/rel/d_a_obj_Lv5Key.h"
 #include "tp/f_op_actor_iter.h"
+#include "tp/d_meter2_draw.h"
 
 namespace mod::events
 {
@@ -128,6 +129,10 @@ namespace mod::events
      * @param flag The event flag that we want to set
      */
     void setSaveFileEventFlag(uint16_t flag);
+
+    void modifyLanternMeterColor(libtp::tp::d_pane_class::CPaneMgr* panePtr,
+                                 libtp::tp::JUtility::TColor* color1,
+                                 libtp::tp::JUtility::TColor* color2);
 
     void onAdjustFieldItemParams(libtp::tp::f_op_actor::fopAc_ac_c* fopAC, void* daObjLife);
 

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -86,6 +86,7 @@ namespace mod
     extern bool instantTextEnabled;
     extern bool increaseSpinnerSpeed;
     extern bool transformAnywhereEnabled;
+    extern uint8_t damageMultiplier;
 
 #ifdef TP_EU
     extern libtp::tp::d_s_logo::Languages currentLanguage;
@@ -289,9 +290,9 @@ namespace mod
 
     int32_t handle_checkItemGet(uint8_t item, int32_t defaultValue);
     extern int32_t (*return_checkItemGet)(uint8_t item, int32_t defaultValue);
-    
+
     void handle_item_func_ASHS_SCRIBBLING();
-    extern void ( *return_item_func_ASHS_SCRIBBLING )();
+    extern void (*return_item_func_ASHS_SCRIBBLING)();
 
     // Message functions
     bool handle_setMessageCode_inSequence(libtp::tp::control::TControl* control,
@@ -388,6 +389,9 @@ namespace mod
 
     libtp::tp::f_op_actor::fopAc_ac_c* handle_searchBouDoor(libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);
     extern libtp::tp::f_op_actor::fopAc_ac_c* (*return_searchBouDoor)(libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);
+
+    float handle_damageMagnification(libtp::tp::d_a_alink::daAlink* daALink, int32_t param_1, int32_t param_2);
+    extern float (*return_damageMagnification)(libtp::tp::d_a_alink::daAlink* daALink, int32_t param_1, int32_t param_2);
 
     // Audio functions
     void handle_loadSeWave(void* Z2SceneMgr, uint32_t waveID);

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -391,7 +391,7 @@ namespace mod
     extern libtp::tp::f_op_actor::fopAc_ac_c* (*return_searchBouDoor)(libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);
 
     bool handle_checkCastleTownUseItem(uint16_t item_id);
-    extern bool(*return_checkCastleTownUseItem)(uint16_t item_id);
+    extern bool (*return_checkCastleTownUseItem)(uint16_t item_id);
 
     float handle_damageMagnification(libtp::tp::d_a_alink::daAlink* daALink, int32_t param_1, int32_t param_2);
     extern float (*return_damageMagnification)(libtp::tp::d_a_alink::daAlink* daALink, int32_t param_1, int32_t param_2);

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -289,6 +289,9 @@ namespace mod
 
     int32_t handle_checkItemGet(uint8_t item, int32_t defaultValue);
     extern int32_t (*return_checkItemGet)(uint8_t item, int32_t defaultValue);
+    
+    void handle_item_func_ASHS_SCRIBBLING();
+    extern void ( *return_item_func_ASHS_SCRIBBLING )();
 
     // Message functions
     bool handle_setMessageCode_inSequence(libtp::tp::control::TControl* control,

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -389,6 +389,9 @@ namespace mod
     libtp::tp::f_op_actor::fopAc_ac_c* handle_searchBouDoor(libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);
     extern libtp::tp::f_op_actor::fopAc_ac_c* (*return_searchBouDoor)(libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);
 
+    bool handle_checkCastleTownUseItem(uint16_t item_id);
+    extern bool(*return_checkCastleTownUseItem)(uint16_t item_id);
+
     // Audio functions
     void handle_loadSeWave(void* Z2SceneMgr, uint32_t waveID);
     extern void (*return_loadSeWave)(void* Z2SceneMgr, uint32_t waveID);

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -87,6 +87,7 @@ namespace mod
     extern bool increaseSpinnerSpeed;
     extern bool transformAnywhereEnabled;
     extern uint8_t damageMultiplier;
+    extern bool bonksDoDamage;
 
 #ifdef TP_EU
     extern libtp::tp::d_s_logo::Languages currentLanguage;
@@ -99,6 +100,7 @@ namespace mod
     float intToFloat(int32_t value);
     void handleInput(uint32_t inputs);
     void handleFoolishItem();
+    void handleBonkDamage();
 
     // Inline getConsole, as it's just a shortcut to get a reference to the console variable
     inline libtp::display::Console& getConsole()
@@ -386,6 +388,15 @@ namespace mod
 
     void handle_setWolfLockDomeModel(libtp::tp::d_a_alink::daAlink* daALink);
     extern void (*return_setWolfLockDomeModel)(libtp::tp::d_a_alink::daAlink* daALink);
+
+    bool handle_procFrontRollCrashInit(libtp::tp::d_a_alink::daAlink* daALink);
+    extern bool (*return_procFrontRollCrashInit)(libtp::tp::d_a_alink::daAlink* daALink);
+
+    bool handle_procWolfDashReverseInit(libtp::tp::d_a_alink::daAlink* daALink, bool param_1);
+    extern bool (*return_procWolfDashReverseInit)(libtp::tp::d_a_alink::daAlink* daALink, bool param_1);
+
+    bool handle_procWolfAttackReverseInit(libtp::tp::d_a_alink::daAlink* daALink);
+    extern bool (*return_procWolfAttackReverseInit)(libtp::tp::d_a_alink::daAlink* daALink);
 
     libtp::tp::f_op_actor::fopAc_ac_c* handle_searchBouDoor(libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);
     extern libtp::tp::f_op_actor::fopAc_ac_c* (*return_searchBouDoor)(libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);

--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -26,8 +26,9 @@ namespace mod::rando
 
     struct Header
     {
-        /* 0x00 */ uint16_t versionMajor;     // SeedData version major
-        /* 0x02 */ uint16_t versionMinor;     // SeedData version minor
+        /* 0x00 */ uint32_t version; // SeedData version major and minor; uint16_t for each. Need to handle as a single variable
+                                     // to get around a compiler warning about comparing an unsigned value to 0
+
         /* 0x04 */ uint16_t headerSize;       // Total size of the header in bytes
         /* 0x06 */ uint16_t dataSize;         // Total number of bytes of seed data
         /* 0x08 */ uint32_t totalSize;        // Total number of bytes in the GCI
@@ -70,10 +71,11 @@ namespace mod::rando
     // Minimum amount of data needed for keeping track of a seed
     struct MinSeedInfo
     {
-        uint16_t versionMajor; // SeedData version major
-        uint16_t versionMinor; // SeedData version minor
-        uint32_t totalSize;    // Total number of bytes in the GCI
-        uint8_t fileIndex;     // (0-126)
+        uint32_t version; // SeedData version major and minor; uint16_t for each. Need to handle as a single variable
+                          // to get around a compiler warning about comparing an unsigned value to 0
+
+        uint32_t totalSize; // Total number of bytes in the GCI
+        uint8_t fileIndex;  // (0-126)
         char fileName[CARD_FILENAME_MAX + 1];
         uint8_t padding[2];
     } __attribute__((__packed__));

--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -65,7 +65,8 @@ namespace mod::rando
         /* 0x53 */ uint8_t palaceRequirements;
         /* 0x54 */ uint8_t mapClearBits;
         /* 0x55 */ uint8_t damageMagnification;
-        /* 0x56 */ uint8_t padding[2];
+        /* 0x56 */ uint8_t bonksDoDamage;
+        /* 0x57 */ uint8_t padding;
     } __attribute__((__packed__));
 
     // Minimum amount of data needed for keeping track of a seed

--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -63,7 +63,8 @@ namespace mod::rando
         /* 0x52 */ uint8_t castleRequirements;
         /* 0x53 */ uint8_t palaceRequirements;
         /* 0x54 */ uint8_t mapClearBits;
-        /* 0x55 */ uint8_t padding[3];
+        /* 0x55 */ uint8_t damageMagnification;
+        /* 0x56 */ uint8_t padding[2];
     } __attribute__((__packed__));
 
     // Minimum amount of data needed for keeping track of a seed

--- a/GameCube/include/rando/seedlist.h
+++ b/GameCube/include/rando/seedlist.h
@@ -16,11 +16,6 @@
 
 #define SEED_MAX_ENTRIES CARD_MAX_FILE
 
-// SeedData version (Major.Minor) which this version of the Randomizer
-// supports.
-#define SUPPORTED_SEED_DATA_VER_MAJOR 1
-#define SUPPORTED_SEED_DATA_VER_MINOR 1
-
 namespace mod::rando
 {
     class SeedList

--- a/GameCube/include/rando/seedlist.h
+++ b/GameCube/include/rando/seedlist.h
@@ -19,22 +19,7 @@
 // SeedData version (Major.Minor) which this version of the Randomizer
 // supports.
 #define SUPPORTED_SEED_DATA_VER_MAJOR 1
-#define SUPPORTED_SEED_DATA_VER_MINOR 0
-
-// Defines to help with version comparisions, as otherwise we get: "error:
-// comparison is always true due to limited range of data type
-// [-Werror=type-limits]" when the macro values are 0.
-#if SUPPORTED_SEED_DATA_VER_MAJOR == 0
-#define CHECK_SUPPORTED_SEED_DATA_VER_MAJOR(version) 1
-#else
-#define CHECK_SUPPORTED_SEED_DATA_VER_MAJOR(version) static_cast<uint16_t>(version) == SUPPORTED_SEED_DATA_VER_MAJOR
-#endif
-
-#if SUPPORTED_SEED_DATA_VER_MINOR == 0
-#define CHECK_SUPPORTED_SEED_DATA_VER_MINOR(version) 1
-#else
-#define CHECK_SUPPORTED_SEED_DATA_VER_MINOR(version) static_cast<uint16_t>(version) == SUPPORTED_SEED_DATA_VER_MINOR
-#endif
+#define SUPPORTED_SEED_DATA_VER_MINOR 1
 
 namespace mod::rando
 {

--- a/GameCube/include/rando/seedlist.h
+++ b/GameCube/include/rando/seedlist.h
@@ -19,7 +19,7 @@
 // SeedData version (Major.Minor) which this version of the Randomizer
 // supports.
 #define SUPPORTED_SEED_DATA_VER_MAJOR 1
-#define SUPPORTED_SEED_DATA_VER_MINOR 0
+#define SUPPORTED_SEED_DATA_VER_MINOR 1
 
 // Defines to help with version comparisions, as otherwise we get: "error:
 // comparison is always true due to limited range of data type

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -30,6 +30,7 @@
 #include "tp/rel/ids.h"
 #include "rando/customItems.h"
 #include "tp/f_op_actor_iter.h"
+#include "tp/d_pane_class.h"
 
 namespace mod::events
 {
@@ -1532,6 +1533,27 @@ namespace mod::events
 
         // Return true, as the bool is set and there are no conflicting scenarios to prevent transformation
         return true;
+    }
+
+    KEEP_FUNC void modifyLanternMeterColor(libtp::tp::d_pane_class::CPaneMgr* panePtr,
+                                           libtp::tp::JUtility::TColor* color1,
+                                           libtp::tp::JUtility::TColor* color2)
+    {
+        mod::rando::Seed* seed;
+
+        if (seed = getCurrentSeed(randomizer), seed)
+        {
+            rando::RawRGBTable* rawRGBListPtr = randomizer->m_Seed->m_RawRGBTable;
+
+            uint8_t* lanternColor = reinterpret_cast<uint8_t*>(&rawRGBListPtr->lanternColor);
+            color1->r = lanternColor[0];
+            color1->g = lanternColor[1];
+            color1->b = lanternColor[2];
+            color2->r = lanternColor[0];
+            color2->g = lanternColor[1];
+            color2->b = lanternColor[2];
+        }
+        libtp::tp::d_pane_class::setBlackWhite(panePtr, color1, color2);
     }
 
     KEEP_FUNC void performStaticASMReplacement(uint32_t memoryOffset, uint32_t value)

--- a/GameCube/source/game_patch/04_verifyItemFunctions.cpp
+++ b/GameCube/source/game_patch/04_verifyItemFunctions.cpp
@@ -209,7 +209,7 @@ namespace mod::game_patch
                 case Clawshot:
                 case Double_Clawshots:
                 {
-                   if ( events::haveItem( Clawshot ) || events::haveItem( Double_Clawshots ) )
+                    if (events::haveItem(Clawshot) || events::haveItem(Double_Clawshots))
                     {
                         itemID = Double_Clawshots;
                     }
@@ -311,6 +311,49 @@ namespace mod::game_patch
                     }
 
                     foolishItemsPtr->spawnCount = static_cast<uint8_t>(count);
+                    break;
+                }
+
+                // For ammo, if we don't have the item that can use the ammo, turn it into a blue rupee so that the check
+                // doesn't completely go to waste.
+                case Arrows_10:
+                case Arrows_20:
+                case Arrows_30:
+                {
+                    if (!events::haveItem(Heros_Bow))
+                    {
+                        itemID = Blue_Rupee;
+                    }
+                    break;
+                }
+
+                case Bombling_1:
+                case Bomblings_10:
+                case Bomblings_3:
+                case Bomblings_5:
+                case Water_Bombs_10:
+                case Water_Bombs_15:
+                case Water_Bombs_3:
+                case Water_Bombs_5:
+                case Bombs_10:
+                case Bombs_20:
+                case Bombs_30:
+                case Bombs_5:
+                {
+                    if (!events::haveItem(Goron_Bomb_Bag)) // This is the specific bomb bag that the rando uses when giving
+                                                           // bombs to the player.
+                    {
+                        itemID = Blue_Rupee;
+                    }
+                    break;
+                }
+
+                case Seeds_50:
+                {
+                    if (!events::haveItem(Slingshot))
+                    {
+                        itemID = Blue_Rupee;
+                    }
                     break;
                 }
 

--- a/GameCube/source/game_patch/04_verifyItemFunctions.cpp
+++ b/GameCube/source/game_patch/04_verifyItemFunctions.cpp
@@ -70,21 +70,23 @@ namespace mod::game_patch
     {
         using namespace rando::customItems;
         using namespace libtp::data::items;
-
-        static const uint8_t progressiveSkyBooksList[] = {Ancient_Sky_Book_Empty,
-                                                          Ancient_Sky_Book_First_Character,
-                                                          Ancient_Sky_Book_Second_Character,
-                                                          Ancient_Sky_Book_Third_Character,
-                                                          Ancient_Sky_Book_Fourth_Character,
-                                                          Ancient_Sky_Book_Fifth_Character};
-
-        constexpr uint32_t listLength = sizeof(progressiveSkyBooksList) / sizeof(progressiveSkyBooksList[0]);
-        for (uint32_t i = 0; i < listLength; i++)
+        if (events::haveItem(Ancient_Sky_Book_Completed))
         {
-            const uint32_t item = progressiveSkyBooksList[i];
-            if (!events::haveItem(item))
+            static const uint8_t progressiveSkyBooksList[] = {Ancient_Sky_Book_Empty,
+                                                              Ancient_Sky_Book_First_Character,
+                                                              Ancient_Sky_Book_Second_Character,
+                                                              Ancient_Sky_Book_Third_Character,
+                                                              Ancient_Sky_Book_Fourth_Character,
+                                                              Ancient_Sky_Book_Fifth_Character};
+
+            constexpr uint32_t listLength = sizeof(progressiveSkyBooksList) / sizeof(progressiveSkyBooksList[0]);
+            for (uint32_t i = 0; i < listLength; i++)
             {
-                return item;
+                const uint32_t item = progressiveSkyBooksList[i];
+                if (!events::haveItem(item))
+                {
+                    return item;
+                }
             }
         }
 
@@ -207,7 +209,7 @@ namespace mod::game_patch
                 case Clawshot:
                 case Double_Clawshots:
                 {
-                    if (events::haveItem(Clawshot))
+                   if ( events::haveItem( Clawshot ) || events::haveItem( Double_Clawshots ) )
                     {
                         itemID = Double_Clawshots;
                     }

--- a/GameCube/source/game_patch/04_verifyItemFunctions.cpp
+++ b/GameCube/source/game_patch/04_verifyItemFunctions.cpp
@@ -70,7 +70,7 @@ namespace mod::game_patch
     {
         using namespace rando::customItems;
         using namespace libtp::data::items;
-        if (events::haveItem(Ancient_Sky_Book_Completed))
+        if (!events::haveItem(Ancient_Sky_Book_Completed))
         {
             static const uint8_t progressiveSkyBooksList[] = {Ancient_Sky_Book_Empty,
                                                               Ancient_Sky_Book_First_Character,

--- a/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
+++ b/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
@@ -62,19 +62,19 @@ namespace mod::game_patch
                 playerReturnPlacePtr->link_room_id = 0x6;
             }
         }
-         else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::stageIDs::Fyrus]))
+         else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::StageIDs::Fyrus]))
         {
             strncpy(playerReturnPlacePtr->link_current_stage,
-                    stagesPtr[stage::stageIDs::Goron_Mines],
+                    stagesPtr[stage::StageIDs::Goron_Mines],
                     sizeof(playerReturnPlacePtr->link_current_stage) - 1);
 
             playerReturnPlacePtr->link_spawn_point_id = 0x0;
             playerReturnPlacePtr->link_room_id = 0x1;
         }
-        else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::stageIDs::Argorok]))
+        else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::StageIDs::Argorok]))
         {
             strncpy(playerReturnPlacePtr->link_current_stage,
-                    stagesPtr[stage::stageIDs::City_in_the_Sky],
+                    stagesPtr[stage::StageIDs::City_in_the_Sky],
                     sizeof(playerReturnPlacePtr->link_current_stage) - 1);
 
             playerReturnPlacePtr->link_spawn_point_id = 0x0;

--- a/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
+++ b/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
@@ -62,5 +62,23 @@ namespace mod::game_patch
                 playerReturnPlacePtr->link_room_id = 0x6;
             }
         }
+         else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::stageIDs::Fyrus]))
+        {
+            strncpy(playerReturnPlacePtr->link_current_stage,
+                    stagesPtr[stage::stageIDs::Goron_Mines],
+                    sizeof(playerReturnPlacePtr->link_current_stage) - 1);
+
+            playerReturnPlacePtr->link_spawn_point_id = 0x0;
+            playerReturnPlacePtr->link_room_id = 0x1;
+        }
+        else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::stageIDs::Argorok]))
+        {
+            strncpy(playerReturnPlacePtr->link_current_stage,
+                    stagesPtr[stage::stageIDs::City_in_the_Sky],
+                    sizeof(playerReturnPlacePtr->link_current_stage) - 1);
+
+            playerReturnPlacePtr->link_spawn_point_id = 0x0;
+            playerReturnPlacePtr->link_room_id = 0x0;
+        }
     }
 } // namespace mod::game_patch

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1782,7 +1782,7 @@ namespace mod
         rando::Seed* seed;
         if (seed = getCurrentSeed(randomizer), seed)
         {
-            ret = ret * static_cast<float>(damageMultiplier);
+            ret *= intToFloat(static_cast<int32_t>(damageMultiplier));
         }
         return ret;
     }
@@ -1793,7 +1793,7 @@ namespace mod
         using namespace libtp::tp::d_a_alink;
         using namespace libtp::tp::d_com_inf_game;
 
-        int32_t roomID = libtp::tools::getCurrentRoomNo();
+        const int32_t roomID = libtp::tools::getCurrentRoomNo();
 
         if (checkStageName(libtp::data::stage::allStages[libtp::data::stage::StageIDs::Sacred_Grove]) &&
             roomID == 0x2) // check if the player is in past area
@@ -1862,6 +1862,8 @@ namespace mod
         using namespace libtp::z2audiolib::z2scenemgr;
         using namespace libtp::tp;
 
+        const uint8_t currentDamageMultiplier = damageMultiplier;
+
         if (!randoIsEnabled(randomizer))
         {
             return;
@@ -1910,12 +1912,12 @@ namespace mod
 
         if (playerStatusPtr->currentForm == 1)
         {
-            newHealthValue = playerStatusPtr->currentHealth - ((2 * count) * damageMultiplier);
+            newHealthValue = playerStatusPtr->currentHealth - ((2 * count) * currentDamageMultiplier);
             d_a_alink::procWolfDamageInit(linkMapPtr, nullptr);
         }
         else
         {
-            newHealthValue = playerStatusPtr->currentHealth - (count * damageMultiplier);
+            newHealthValue = playerStatusPtr->currentHealth - (count * currentDamageMultiplier);
             d_a_alink::procDamageInit(linkMapPtr, nullptr, 0);
         }
 
@@ -1936,14 +1938,15 @@ namespace mod
             d_com_inf_game::dComIfG_inf_c* gameInfoPtr = &d_com_inf_game::dComIfG_gameInfo;
             libtp::tp::d_save::dSv_player_status_a_c* playerStatusPtr = &gameInfoPtr->save.save_file.player.player_status_a;
             int32_t newHealthValue;
+            const uint8_t currentDamageMultiplier = damageMultiplier;
 
             if (playerStatusPtr->currentForm == 1)
             {
-                newHealthValue = playerStatusPtr->currentHealth - (2 * damageMultiplier);
+                newHealthValue = playerStatusPtr->currentHealth - (2 * currentDamageMultiplier);
             }
             else
             {
-                newHealthValue = playerStatusPtr->currentHealth - damageMultiplier; // Damage multiplier is 1 by default
+                newHealthValue = playerStatusPtr->currentHealth - currentDamageMultiplier; // Damage multiplier is 1 by default
             }
 
             // Make sure an underflow doesn't occur

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1850,12 +1850,12 @@ namespace mod
 
         if (playerStatusPtr->currentForm == 1)
         {
-            newHealthValue = playerStatusPtr->currentHealth - (2 * count);
+            newHealthValue = playerStatusPtr->currentHealth - (2 * count * damageMultiplier);
             d_a_alink::procWolfDamageInit(linkMapPtr, nullptr);
         }
         else
         {
-            newHealthValue = playerStatusPtr->currentHealth - count;
+            newHealthValue = playerStatusPtr->currentHealth - (count * damageMultiplier);
             d_a_alink::procDamageInit(linkMapPtr, nullptr, 0);
         }
 

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -180,6 +180,7 @@ namespace mod
     // ItemGet functions.
     KEEP_VAR void (*return_execItemGet)(uint8_t item) = nullptr;
     KEEP_VAR int32_t (*return_checkItemGet)(uint8_t item, int32_t defaultValue) = nullptr;
+    KEEP_VAR void ( *return_item_func_ASHS_SCRIBBLING )() = nullptr;
 
     // Message functions
     KEEP_VAR bool (*return_setMessageCode_inSequence)(libtp::tp::control::TControl* control,
@@ -1104,6 +1105,15 @@ namespace mod
 
         return return_checkItemGet(item, defaultValue);
     }
+     KEEP_FUNC void handle_item_func_ASHS_SCRIBBLING()
+    {
+        using namespace libtp::data::flags;
+        if ( !libtp::tp::d_a_alink::dComIfGs_isEventBit( GOT_CORAL_EARRING_FROM_RALIS ) )
+        {
+            return_item_func_ASHS_SCRIBBLING();
+        }
+    }
+
 
     KEEP_FUNC bool handle_setMessageCode_inSequence(libtp::tp::control::TControl* control,
                                                     const void* TProcessor,

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1850,7 +1850,7 @@ namespace mod
 
         if (playerStatusPtr->currentForm == 1)
         {
-            newHealthValue = playerStatusPtr->currentHealth - (2 * count * damageMultiplier);
+            newHealthValue = playerStatusPtr->currentHealth - ((2 * count) * damageMultiplier);
             d_a_alink::procWolfDamageInit(linkMapPtr, nullptr);
         }
         else

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1778,10 +1778,10 @@ namespace mod
         {
             if (item_id == Ooccoo_Jr)
             {
-                return false; // remove the ability to use oocoo in past area
+                return false; // remove the ability to use ooccoo in past area
             }
         }
-        else if (checkStageName(libtp::data::stage::allStages[libtp::data::stage::StageIDs::Temple_of_Time]) && roomID == 0)
+        else if (checkStageName(libtp::data::stage::allStages[libtp::data::stage::StageIDs::Temple_of_Time]) && roomID == 0x0)
         {
             
                 switch (item_id)

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -181,7 +181,7 @@ namespace mod
     // ItemGet functions.
     KEEP_VAR void (*return_execItemGet)(uint8_t item) = nullptr;
     KEEP_VAR int32_t (*return_checkItemGet)(uint8_t item, int32_t defaultValue) = nullptr;
-    KEEP_VAR void ( *return_item_func_ASHS_SCRIBBLING )() = nullptr;
+    KEEP_VAR void (*return_item_func_ASHS_SCRIBBLING)() = nullptr;
 
     // Message functions
     KEEP_VAR bool (*return_setMessageCode_inSequence)(libtp::tp::control::TControl* control,
@@ -1110,10 +1110,10 @@ namespace mod
 
         return return_checkItemGet(item, defaultValue);
     }
-     KEEP_FUNC void handle_item_func_ASHS_SCRIBBLING()
+    KEEP_FUNC void handle_item_func_ASHS_SCRIBBLING()
     {
         using namespace libtp::data::flags;
-        if ( !libtp::tp::d_a_alink::dComIfGs_isEventBit( GOT_CORAL_EARRING_FROM_RALIS ) )
+        if (!libtp::tp::d_a_alink::dComIfGs_isEventBit(GOT_CORAL_EARRING_FROM_RALIS))
         {
             return_item_func_ASHS_SCRIBBLING();
         }
@@ -1511,7 +1511,7 @@ namespace mod
                     break;
                 }
 
-                case CLEARED_ELDIN_TWILIGHT:                            // Cleared Eldin Twilight
+                case CLEARED_ELDIN_TWILIGHT: // Cleared Eldin Twilight
                 {
                     events::setSaveFileEventFlag(MAP_WARPING_UNLOCKED); // in glitched Logic, you can skip the gorge bridge.
                     if (libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED))
@@ -1532,7 +1532,7 @@ namespace mod
                 {
                     if (libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED))
                     {
-                        if (darkClearLevelFlag == 0x7)                    // All twilights completed
+                        if (darkClearLevelFlag == 0x7) // All twilights completed
                         {
                             playerStatusPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed twilight.
                                                                           // Also puts Midna on the player's back
@@ -1783,110 +1783,108 @@ namespace mod
         }
         else if (checkStageName(libtp::data::stage::allStages[libtp::data::stage::StageIDs::Temple_of_Time]) && roomID == 0x0)
         {
-            
-                switch (item_id)
-                {
-                    case Ooccoo_Jr:
-                    case Ooccoo_FT:
-                    case Ooccoo_Dungeon:
-                    {
-                        if (!libtp::tp::d_save::isDungeonItem(
-                                &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.memory.temp_flags,
-                                0x6)) // check if the player hasn't taken ooccoo at tot entrance
-                        {
-                            return false;
-                        }
-                        break;
-                    }
-                }
-        }
-
-            return return_checkCastleTownUseItem(item_id);
-        }
-
-        KEEP_FUNC void handle_loadSeWave(void* z2SceneMgr, uint32_t waveID)
-        {
-            z2ScenePtr = z2SceneMgr;
-            return return_loadSeWave(z2SceneMgr, waveID);
-        }
-
-        KEEP_FUNC void* handle_dScnLogo_c_dt(void* dScnLogo_c, int16_t bFreeThis)
-        {
-            // Call the original function immediately, as certain values need to be set first
-            void* ret = return_dScnLogo_c_dt(dScnLogo_c, bFreeThis);
-
-            // Initialize bgWindow since mMain2DArchive should now be set
-            if (!bgWindow)
+            switch (item_id)
             {
-                void* main2DArchive = libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mMain2DArchive;
-                if (main2DArchive)
+                case Ooccoo_Jr:
+                case Ooccoo_FT:
+                case Ooccoo_Dungeon:
                 {
-                    // Get the image to use for the background window
-                    void* bg = libtp::tp::JKRArchive::JKRArchive_getResource2(main2DArchive,
-                                                                              0x54494D47, // TIMG
-                                                                              "tt_block_grade.bti");
-
-                    if (bg)
+                    if (!libtp::tp::d_save::isDungeonItem(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.memory.temp_flags,
+                                                          0x6)) // check if the player hasn't taken ooccoo at tot entrance
                     {
-                        bgWindow = new libtp::tp::J2DPicture::J2DPicture(bg);
+                        return false;
                     }
+                    break;
                 }
             }
-
-            return ret;
         }
 
-        KEEP_FUNC void handleFoolishItem()
+        return return_checkCastleTownUseItem(item_id);
+    }
+
+    KEEP_FUNC void handle_loadSeWave(void* z2SceneMgr, uint32_t waveID)
+    {
+        z2ScenePtr = z2SceneMgr;
+        return return_loadSeWave(z2SceneMgr, waveID);
+    }
+
+    KEEP_FUNC void* handle_dScnLogo_c_dt(void* dScnLogo_c, int16_t bFreeThis)
+    {
+        // Call the original function immediately, as certain values need to be set first
+        void* ret = return_dScnLogo_c_dt(dScnLogo_c, bFreeThis);
+
+        // Initialize bgWindow since mMain2DArchive should now be set
+        if (!bgWindow)
         {
-            using namespace libtp::z2audiolib;
-            using namespace libtp::z2audiolib::z2scenemgr;
-            using namespace libtp::tp;
-
-            if (!randoIsEnabled(randomizer))
+            void* main2DArchive = libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mMain2DArchive;
+            if (main2DArchive)
             {
-                return;
+                // Get the image to use for the background window
+                void* bg = libtp::tp::JKRArchive::JKRArchive_getResource2(main2DArchive,
+                                                                          0x54494D47, // TIMG
+                                                                          "tt_block_grade.bti");
+
+                if (bg)
+                {
+                    bgWindow = new libtp::tp::J2DPicture::J2DPicture(bg);
+                }
             }
+        }
 
-            // Get the trigger count
-            uint8_t* triggerCount = &rando::foolishItems.triggerCount;
-            uint32_t count = *triggerCount;
-            if (count == 0)
-            {
-                return;
-            }
+        return ret;
+    }
 
-            if (!events::checkFoolItemFreeze())
-            {
-                return;
-            }
+    KEEP_FUNC void handleFoolishItem()
+    {
+        using namespace libtp::z2audiolib;
+        using namespace libtp::z2audiolib::z2scenemgr;
+        using namespace libtp::tp;
 
-            // Failsafe: Make sure the count does not somehow exceed 100
-            if (count > 100)
-            {
-                count = 100;
-            }
-            // reset trigger counter to 0
-            *triggerCount = 0;
+        if (!randoIsEnabled(randomizer))
+        {
+            return;
+        }
 
-            /* Store the currently loaded sound wave to local variables as we will need to load them back later.
-             * We use this method because if we just loaded the sound waves every time the item was gotten, we'd
-             * eventually run out of memory so it is safer to unload everything and load it back in. */
-            z2scenemgr::Z2SceneMgr* sceneMgrPtr = &z2audiomgr::g_mDoAud_zelAudio.mSceneMgr;
-            const uint32_t seWave1 = sceneMgrPtr->SeWaveToErase_1;
-            const uint32_t seWave2 = sceneMgrPtr->SeWaveToErase_2;
+        // Get the trigger count
+        uint8_t* triggerCount = &rando::foolishItems.triggerCount;
+        uint32_t count = *triggerCount;
+        if (count == 0)
+        {
+            return;
+        }
 
-            void* scenePtr = z2ScenePtr;
-            eraseSeWave(scenePtr, seWave1);
-            eraseSeWave(scenePtr, seWave2);
-            loadSeWave(scenePtr, 0x46);
-            m_Do_Audio::mDoAud_seStartLevel(0x10040, nullptr, 0, 0);
-            loadSeWave(scenePtr, seWave1);
-            loadSeWave(scenePtr, seWave2);
+        if (!events::checkFoolItemFreeze())
+        {
+            return;
+        }
 
-            d_com_inf_game::dComIfG_inf_c* gameInfoPtr = &d_com_inf_game::dComIfG_gameInfo;
-            libtp::tp::d_save::dSv_player_status_a_c* playerStatusPtr = &gameInfoPtr->save.save_file.player.player_status_a;
-            d_a_alink::daAlink* linkMapPtr = gameInfoPtr->play.mPlayer;
-            int32_t newHealthValue;
+        // Failsafe: Make sure the count does not somehow exceed 100
+        if (count > 100)
+        {
+            count = 100;
+        }
+        // reset trigger counter to 0
+        *triggerCount = 0;
+
+        /* Store the currently loaded sound wave to local variables as we will need to load them back later.
+         * We use this method because if we just loaded the sound waves every time the item was gotten, we'd
+         * eventually run out of memory so it is safer to unload everything and load it back in. */
+        z2scenemgr::Z2SceneMgr* sceneMgrPtr = &z2audiomgr::g_mDoAud_zelAudio.mSceneMgr;
+        const uint32_t seWave1 = sceneMgrPtr->SeWaveToErase_1;
+        const uint32_t seWave2 = sceneMgrPtr->SeWaveToErase_2;
+
+        void* scenePtr = z2ScenePtr;
+        eraseSeWave(scenePtr, seWave1);
+        eraseSeWave(scenePtr, seWave2);
+        loadSeWave(scenePtr, 0x46);
+        m_Do_Audio::mDoAud_seStartLevel(0x10040, nullptr, 0, 0);
+        loadSeWave(scenePtr, seWave1);
+        loadSeWave(scenePtr, seWave2);
+
+        d_com_inf_game::dComIfG_inf_c* gameInfoPtr = &d_com_inf_game::dComIfG_gameInfo;
+        libtp::tp::d_save::dSv_player_status_a_c* playerStatusPtr = &gameInfoPtr->save.save_file.player.player_status_a;
+        d_a_alink::daAlink* linkMapPtr = gameInfoPtr->play.mPlayer;
+        int32_t newHealthValue;
 
         if (playerStatusPtr->currentForm == 1)
         {
@@ -1899,62 +1897,62 @@ namespace mod
             d_a_alink::procDamageInit(linkMapPtr, nullptr, 0);
         }
 
-            // Make sure an underflow doesn't occur
-            if (newHealthValue < 0)
-            {
-                newHealthValue = 0;
-            }
-
-            playerStatusPtr->currentHealth = static_cast<uint16_t>(newHealthValue);
+        // Make sure an underflow doesn't occur
+        if (newHealthValue < 0)
+        {
+            newHealthValue = 0;
         }
 
-        KEEP_FUNC libtp::tp::d_resource::dRes_info_c* handle_getResInfo(const char* arcName,
-                                                                        libtp::tp::d_resource::dRes_info_c* objectInfo,
-                                                                        int32_t size)
-        {
-            libtp::tp::d_resource::dRes_info_c* resourcePtr = return_getResInfo(arcName, objectInfo, size);
+        playerStatusPtr->currentHealth = static_cast<uint16_t>(newHealthValue);
+    }
 
+    KEEP_FUNC libtp::tp::d_resource::dRes_info_c* handle_getResInfo(const char* arcName,
+                                                                    libtp::tp::d_resource::dRes_info_c* objectInfo,
+                                                                    int32_t size)
+    {
+        libtp::tp::d_resource::dRes_info_c* resourcePtr = return_getResInfo(arcName, objectInfo, size);
+
+        rando::Randomizer* rando = randomizer;
+        if (getCurrentSeed(rando) && resourcePtr)
+        {
+            rando->overrideObjectARC(resourcePtr, arcName);
+        }
+
+        return resourcePtr;
+    }
+
+    // This is called in the NON-MAIN thread which is loading the archive where
+    // `mountArchive->mIsDone = true;` would be called normally (this is the
+    // last thing that gets called before the archive is considered loaded). The
+    // archive is no longer automatically marked as loaded, so we need to do
+    // this ourselves when we are done. (This indicates that the archive is
+    // loaded, and whatever was waiting on it will see this byte change the next
+    // time it polls the completion status (polling happens once per frame?))
+    KEEP_FUNC bool handle_mountArchive__execute(libtp::tp::m_Do_dvd_thread::mDoDvdThd_mountArchive_c* mountArchive)
+    {
+        const bool ret = return_mountArchive__execute(mountArchive);
+
+        if (ret)
+        {
+            // Make sure the randomizer is loaded/enabled and a seed is loaded
+            rando::Seed* seed;
             rando::Randomizer* rando = randomizer;
-            if (getCurrentSeed(rando) && resourcePtr)
-            {
-                rando->overrideObjectARC(resourcePtr, arcName);
-            }
 
-            return resourcePtr;
+            if (seed = getCurrentSeed(rando), seed)
+            {
+                rando->recolorArchiveTextures(mountArchive);
+            }
         }
 
-        // This is called in the NON-MAIN thread which is loading the archive where
-        // `mountArchive->mIsDone = true;` would be called normally (this is the
-        // last thing that gets called before the archive is considered loaded). The
-        // archive is no longer automatically marked as loaded, so we need to do
-        // this ourselves when we are done. (This indicates that the archive is
-        // loaded, and whatever was waiting on it will see this byte change the next
-        // time it polls the completion status (polling happens once per frame?))
-        KEEP_FUNC bool handle_mountArchive__execute(libtp::tp::m_Do_dvd_thread::mDoDvdThd_mountArchive_c * mountArchive)
-        {
-            const bool ret = return_mountArchive__execute(mountArchive);
+        // Need to mark the archive as loaded once we are done modifying its
+        // contents.
+        mountArchive->mIsDone = true;
 
-            if (ret)
-            {
-                // Make sure the randomizer is loaded/enabled and a seed is loaded
-                rando::Seed* seed;
-                rando::Randomizer* rando = randomizer;
+        return ret;
+    };
 
-                if (seed = getCurrentSeed(rando), seed)
-                {
-                    rando->recolorArchiveTextures(mountArchive);
-                }
-            }
-
-            // Need to mark the archive as loaded once we are done modifying its
-            // contents.
-            mountArchive->mIsDone = true;
-
-            return ret;
-        };
-
-        float __attribute__((noinline)) intToFloat(int32_t value)
-        {
-            return static_cast<float>(value);
-        }
-    } // namespace mod
+    float __attribute__((noinline)) intToFloat(int32_t value)
+    {
+        return static_cast<float>(value);
+    }
+} // namespace mod

--- a/GameCube/source/rando/randomizer.cpp
+++ b/GameCube/source/rando/randomizer.cpp
@@ -535,7 +535,7 @@ namespace mod::rando
             goldenWolfItemReplacementPtr->flag = flag;
 
             goldenWolfItemReplacementPtr->itemActorId =
-                initCreatePlayerItem(currentHiddenSkillCheck->itemID,
+                initCreatePlayerItem(game_patch::_04_verifyProgressiveItem(this, currentHiddenSkillCheck->itemID),
                                      0xFF,
                                      reinterpret_cast<float*>(reinterpret_cast<uint32_t>(daNpcGWolfPtr) + 0x4d0),
                                      currentRoom,

--- a/GameCube/subrel/boot/source/game_patch/06_asmOverrides.cpp
+++ b/GameCube/subrel/boot/source/game_patch/06_asmOverrides.cpp
@@ -15,6 +15,7 @@
 #include "tp/m_Do_dvd_thread.h"
 #include "Z2AudioLib/Z2SceneMgr.h"
 #include "tp/d_msg_object.h"
+#include "tp/d_meter2_draw.h"
 
 namespace mod::game_patch
 {
@@ -97,6 +98,10 @@ namespace mod::game_patch
         libtp::patch::writeBranchBL(isSendAddress + 0xE4, events::autoMashThroughText);
         libtp::patch::writeBranchBL(isSendAddress + 0x160, events::autoMashThroughText);
         libtp::patch::writeBranchBL(isSendAddress + 0x1B8, events::autoMashThroughText);
+
+        // Modify drawKanteraScreen to change the lantern meter color to match lantern light color from seed.
+        uint32_t drawKanteraAddress = reinterpret_cast<uint32_t>(libtp::tp::d_meter2_draw::drawKanteraScreen);
+        libtp::patch::writeBranchBL(drawKanteraAddress + 0xE4, events::modifyLanternMeterColor);
 #ifdef TP_JP
         uint32_t checkWarpStartAddress = reinterpret_cast<uint32_t>(libtp::tp::d_a_alink::checkWarpStart);
 

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -219,6 +219,7 @@ patch::hookFunction( libtp::tp::d_item::item_func_ASHS_SCRIBBLING, mod::handle_i
             patch::hookFunction(libtp::tp::d_a_alink::setWolfLockDomeModel, mod::handle_setWolfLockDomeModel);
 
         return_searchBouDoor = patch::hookFunction(libtp::tp::d_a_alink::searchBouDoor, mod::handle_searchBouDoor);
+        return_checkCastleTownUseItem = patch::hookFunction(libtp::tp::d_a_alink::checkCastleTownUseItem, mod::handle_checkCastleTownUseItem);
 
         // Audio functions
         return_loadSeWave = patch::hookFunction(libtp::z2audiolib::z2scenemgr::loadSeWave, mod::handle_loadSeWave);

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -160,7 +160,7 @@ namespace mod
         return_execItemGet = patch::hookFunction(libtp::tp::d_item::execItemGet, mod::handle_execItemGet);
         return_checkItemGet = patch::hookFunction(libtp::tp::d_item::checkItemGet, mod::handle_checkItemGet);
         return_item_func_ASHS_SCRIBBLING =
-patch::hookFunction( libtp::tp::d_item::item_func_ASHS_SCRIBBLING, mod::handle_item_func_ASHS_SCRIBBLING );
+            patch::hookFunction(libtp::tp::d_item::item_func_ASHS_SCRIBBLING, mod::handle_item_func_ASHS_SCRIBBLING);
 
         // Message Functions
         return_setMessageCode_inSequence =
@@ -218,8 +218,18 @@ patch::hookFunction( libtp::tp::d_item::item_func_ASHS_SCRIBBLING, mod::handle_i
         return_setWolfLockDomeModel =
             patch::hookFunction(libtp::tp::d_a_alink::setWolfLockDomeModel, mod::handle_setWolfLockDomeModel);
 
+        return_procFrontRollCrashInit =
+            patch::hookFunction(libtp::tp::d_a_alink::procFrontRollCrashInit, mod::handle_procFrontRollCrashInit);
+
+        return_procWolfDashReverseInit =
+            patch::hookFunction(libtp::tp::d_a_alink::procWolfDashReverseInit, mod::handle_procWolfDashReverseInit);
+
+        return_procWolfAttackReverseInit =
+            patch::hookFunction(libtp::tp::d_a_alink::procWolfAttackReverseInit, mod::handle_procWolfAttackReverseInit);
+
         return_searchBouDoor = patch::hookFunction(libtp::tp::d_a_alink::searchBouDoor, mod::handle_searchBouDoor);
-        return_checkCastleTownUseItem = patch::hookFunction(libtp::tp::d_a_alink::checkCastleTownUseItem, mod::handle_checkCastleTownUseItem);
+        return_checkCastleTownUseItem =
+            patch::hookFunction(libtp::tp::d_a_alink::checkCastleTownUseItem, mod::handle_checkCastleTownUseItem);
 
         return_damageMagnification =
             patch::hookFunction(libtp::tp::d_a_alink::damageMagnification, mod::handle_damageMagnification);

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -220,6 +220,9 @@ patch::hookFunction( libtp::tp::d_item::item_func_ASHS_SCRIBBLING, mod::handle_i
 
         return_searchBouDoor = patch::hookFunction(libtp::tp::d_a_alink::searchBouDoor, mod::handle_searchBouDoor);
 
+        return_damageMagnification =
+            patch::hookFunction(libtp::tp::d_a_alink::damageMagnification, mod::handle_damageMagnification);
+
         // Audio functions
         return_loadSeWave = patch::hookFunction(libtp::z2audiolib::z2scenemgr::loadSeWave, mod::handle_loadSeWave);
         return_sceneChange = patch::hookFunction(libtp::z2audiolib::z2scenemgr::sceneChange, mod::handle_sceneChange);

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -159,6 +159,8 @@ namespace mod
         // ItemGet functions
         return_execItemGet = patch::hookFunction(libtp::tp::d_item::execItemGet, mod::handle_execItemGet);
         return_checkItemGet = patch::hookFunction(libtp::tp::d_item::checkItemGet, mod::handle_checkItemGet);
+        return_item_func_ASHS_SCRIBBLING =
+patch::hookFunction( libtp::tp::d_item::item_func_ASHS_SCRIBBLING, mod::handle_item_func_ASHS_SCRIBBLING );
 
         // Message Functions
         return_setMessageCode_inSequence =

--- a/GameCube/subrel/boot/source/rando/seedlist.cpp
+++ b/GameCube/subrel/boot/source/rando/seedlist.cpp
@@ -150,16 +150,17 @@ namespace mod::rando
             }
 
             // Make sure the seed version is supported
-            const uint16_t versionMajor = header.versionMajor;
-            const uint16_t versionMinor = header.versionMinor;
+            const uint32_t currentSeedVersion = header.version;
 
-            if (CHECK_SUPPORTED_SEED_DATA_VER_MAJOR(versionMajor) && CHECK_SUPPORTED_SEED_DATA_VER_MINOR(versionMinor))
+            // The major and minor seed versions use 2 bytes each, so merge both into a single 4 byte variable
+            constexpr uint32_t supportedSeedVersion = (SUPPORTED_SEED_DATA_VER_MAJOR << 16) | SUPPORTED_SEED_DATA_VER_MINOR;
+
+            if (currentSeedVersion == supportedSeedVersion)
             {
                 MinSeedInfo* currentMinSeedInfo = &minSeedInfoBuffer[index];
 
                 // Copy the seed version
-                currentMinSeedInfo->versionMajor = versionMajor;
-                currentMinSeedInfo->versionMinor = versionMinor;
+                currentMinSeedInfo->version = currentSeedVersion;
 
                 // Copy the total number of bytes in the GCI
                 currentMinSeedInfo->totalSize = header.totalSize;

--- a/GameCube/subrel/boot/source/rando/seedlist.cpp
+++ b/GameCube/subrel/boot/source/rando/seedlist.cpp
@@ -153,7 +153,7 @@ namespace mod::rando
             const uint32_t currentSeedVersion = header.version;
 
             // The major and minor seed versions use 2 bytes each, so merge both into a single 4 byte variable
-            constexpr uint32_t supportedSeedVersion = (SUPPORTED_SEED_DATA_VER_MAJOR << 16) | SUPPORTED_SEED_DATA_VER_MINOR;
+            constexpr uint32_t supportedSeedVersion = (_VERSION_MAJOR << 16) | _VERSION_MINOR;
 
             if (currentSeedVersion == supportedSeedVersion)
             {

--- a/GameCube/subrel/seed/source/main.cpp
+++ b/GameCube/subrel/seed/source/main.cpp
@@ -37,6 +37,9 @@ namespace mod
                 // Make sure transformAnywhereEnabled is properly initialized
                 transformAnywhereEnabled = false;
 
+                // Make sure the damage multiplier is properly initialized
+                damageMultiplier = 1;
+
                 // The randomizer constructor sets m_Enabled to true
                 // Align to void*, as pointers use the largest variable type in the Randomizer class
                 randomizer = new (sizeof(void*)) rando::Randomizer(&seedList->m_minSeedInfo[selectedSeed], selectedSeed);

--- a/GameCube/subrel/seed/source/rando/randomizer.cpp
+++ b/GameCube/subrel/seed/source/rando/randomizer.cpp
@@ -49,6 +49,7 @@ namespace mod::rando
             {
                 // Update transformAnywhereEnabled now that a seed is loaded
                 transformAnywhereEnabled = static_cast<bool>(m_Seed->m_Header->transformAnywhere);
+                damageMultiplier = m_Seed->m_Header->damageMagnification;
 
                 // Load checks for first load
                 onStageLoad();

--- a/GameCube/subrel/seed/source/rando/randomizer.cpp
+++ b/GameCube/subrel/seed/source/rando/randomizer.cpp
@@ -49,7 +49,12 @@ namespace mod::rando
             {
                 // Update transformAnywhereEnabled now that a seed is loaded
                 transformAnywhereEnabled = static_cast<bool>(m_Seed->m_Header->transformAnywhere);
+
+                // Update the damage multiplier to the value stored in the seed
                 damageMultiplier = m_Seed->m_Header->damageMagnification;
+
+                // Update bonksDoDamage now that a seed is loaded
+                bonksDoDamage = static_cast<bool>(m_Seed->m_Header->bonksDoDamage);
 
                 // Load checks for first load
                 onStageLoad();


### PR DESCRIPTION
- Applied a patch where save warping in Argorok or Fyrus' Boss room places you outside the room. 
- Added modified item functions to support the new "Item Scarcity" setting.
- Added support for the "Damage Multiplier" setting.
- Ammunition and refills now appear as blue rupees if the player is not able to use them. (Example: If the player does not have the Bow, then instead of getting an arrow refill from a check, they would instead get a Blue Rupee). 
- Added a patch so that Ooccoo cannot be used in the Sacred Grove Temple of Time or the Temple of Time Entrance to prevent a softlock. 
- Added the functionality so that the Lantern Oil meter color matches the Lantern light color.
- Added a new setting called "Bonks Do Damage" where Link/Wolf takes damage if they "bonk" (roll/headbutt) against a wall. The base damage is 1/4 Heart for Link and 1/2 Heart for Wolf Link and does stack with the Damage Multiplier setting.
- Fixed an issue where unsupported seed could incorrectly be labeled as supported. 
- Fixed an issue where Golden Wolf checks would not show the proper progression item when on the ground. 