### PR TITLE
Pushing current 1.2 changes to zsrtp repo

### DIFF
--- a/GameCube/Makefile
+++ b/GameCube/Makefile
@@ -14,7 +14,7 @@ export BUILDID:='"$(shell date +'%Y%m%d%H%M')"'
 
 # Version
 export _VERSION_MAJOR:=1
-export _VERSION_MINOR:=1
+export _VERSION_MINOR:=2
 export _VERSION_PATCH:=0
 export _VERSION:='"$(_VERSION_MAJOR).$(_VERSION_MINOR).$(_VERSION_PATCH)"'
 # Variant: i.e. Public, NoLogic, Race, etc.

--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -76,7 +76,7 @@
 80042B04:skipper
 
 // d_event_manager.o
-80047888:getEventIdx
+80047888:getEventIdx3
 
 // DynamicLink.o
 80263460:DynamicModuleControl_ct
@@ -101,6 +101,9 @@
 80019e40:fopAcM_create
 8001bbbc:fopAcM_getTalkEventPartner
 8001b68c:fopAcM_orderChangeEventId
+
+// f_op_msg_mng.o
+8001ff2c:fopMsgM_messageSet
 
 // f_pc_node_req
 803A5718:l_fpcNdRq_Queue
@@ -361,6 +364,10 @@
 //d_a_shop_item_static.o
 8037a178:shopItemData
 
+//d_shop_system.o
+8019a080:seq_decide_yes
+8019a5ac:setSoldOutFlag
+
 //d_menu_window.o
 801fa854:collect_save_open_init
 
@@ -377,6 +384,8 @@
 8024e11c:event041
 8024d138:event017
 8024c944:query049
+8024a97c:doFlow
+8024b0f4:setNormalMsg
 
 
 //d_a_npc.o

--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -75,6 +75,9 @@
 800428A8:defaultSkipStb
 80042B04:skipper
 
+// d_event_manager.o
+80047888:getEventIdx
+
 // DynamicLink.o
 80263460:DynamicModuleControl_ct
 80263A5C:do_link
@@ -97,6 +100,7 @@
 80019B50:CreateAppend
 80019e40:fopAcM_create
 8001bbbc:fopAcM_getTalkEventPartner
+8001b68c:fopAcM_orderChangeEventId
 
 // f_pc_node_req
 803A5718:l_fpcNdRq_Queue
@@ -124,13 +128,13 @@
 8039325C:getSeType
 800c7a00:procCoMetamorphoseInit
 80115E2C:checkEventRun
-803DEDF4:linkStatus
 800e2728:checkBootsMoveAnime
 800d9148:procDamageInit
 800d7e4c:checkDamageAction
 801183ac:setGetItemFace
 801362f8:procWolfDamageInit
 8011ae34:procCoGetItem
+8011a9a4:procCoGetItemInit
 800d01b0:dComIfGp_setItemLifeCount
 800be5f0:checkRestartRoom
 8011fbf8:checkWarpStart
@@ -152,7 +156,6 @@
 
 //d_meter2_info.o
 80432148:g_meter2_info
-80432164:wZButtonPtr
 8021e388:resetMiniGameItem
 
 //d_meter2_draw.o

--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -314,6 +314,7 @@
 // Z2SeqMgr
 802B5CB0:startBattleBgm
 802ad30c:seStartLevel
+802b4cac:checkBgmIDPlaying
 
 // Z2SoundMgr.o
 802AACE8:startSound
@@ -457,3 +458,6 @@
 
 // f_op_actor_iter.o
 800198A0:fopAcIt_Judge
+
+// d_gameover.o
+8019b664:dispWait_init

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -76,7 +76,7 @@
 800429D4:skipper
 
 // d_event_manager.o
-80047758:getEventIdx
+80047758:getEventIdx3
 
 // DynamicLink.o
 80264A90:DynamicModuleControl_ct
@@ -101,6 +101,9 @@
 80019d98:fopAcM_create
 8001bb14:fopAcM_getTalkEventPartner
 8001b5e4:fopAcM_orderChangeEventId
+
+// f_op_msg_mng.o
+8001fe84:fopMsgM_messageSet
 
 // f_pc_node_req
 8039DB98:l_fpcNdRq_Queue
@@ -377,6 +380,8 @@
 8024f3e0:event041
 8024f130:event035
 8024dc08:query049
+8024bc40:doFlow
+8024c3b8:setNormalMsg
 
 // d_a_npc.o
 8014ca78:daNpcT_onEvtBit
@@ -391,6 +396,10 @@
 
 // d_a_shop_item_static.o
 8037b790:shopItemData
+
+// d_shop_system.o
+80199de8:seq_decide_yes
+8019a314:setSoldOutFlag
 
 // d_meter2_info.o
 8042a2c8:g_meter2_info

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -303,6 +303,7 @@
 
 // Z2SeqMgr.o
 802B72F0:startBattleBgm
+802b62ec:checkBgmIDPlaying
 
 // Z2SoundMgr.o
 802AC328:startSound
@@ -452,3 +453,6 @@
 
 // f_op_actor_iter.o
 800197F8:fopAcIt_Judge
+
+// d_gameover.o
+8019b3cc:dispWait_init

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -75,6 +75,9 @@
 80042778:defaultSkipStb
 800429D4:skipper
 
+// d_event_manager.o
+80047758:getEventIdx
+
 // DynamicLink.o
 80264A90:DynamicModuleControl_ct
 8026508C:do_link
@@ -97,6 +100,7 @@
 80019AA8:CreateAppend
 80019d98:fopAcM_create
 8001bb14:fopAcM_getTalkEventPartner
+8001b5e4:fopAcM_orderChangeEventId
 
 // f_pc_node_req
 8039DB98:l_fpcNdRq_Queue
@@ -125,12 +129,12 @@
 800e2554:checkBootsMoveAnime
 801181d8:setGetItemFace
 8038badc:getSeType
-803D6F94:linkStatus
 80141188:mDoAud_seStartLevel
 80136138:procWolfDamageInit
 800d8f74:procDamageInit
 801412b0:dComIfGs_isItemFirstBit
 8011ac60:procCoGetItem
+8011a7d0:procCoGetItemInit
 800cffdc:dComIfGp_setItemLifeCount
 800be41c:checkRestartRoom
 8011fa24:checkWarpStart
@@ -389,7 +393,6 @@
 8037b790:shopItemData
 
 // d_meter2_info.o
-8042A2E4:wZButtonPtr
 8042a2c8:g_meter2_info
 8021e81c:resetMiniGameItem
 

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -98,6 +98,9 @@
 80019D98:fopAcM_create
 8001bb14:fopAcM_getTalkEventPartner
 
+// f_op_msg_mng.o
+8001fe84:fopMsgM_messageSet
+
 // f_pc_node_req
 803A3A38:l_fpcNdRq_Queue
 
@@ -359,6 +362,7 @@
 
 // d_msg_object.o
 802369D8:isSend
+802383d0:getMessageID
 
 // processor.o
 802A7C54:getResource_groupID
@@ -376,6 +380,9 @@
 8024da78:event041
 8024bc80:query037
 8024c2a0:query049
+8024a2d8:doFlow
+8024a528:getEventId
+8024aa50:setNormalMsg
 
 //d_menu_window.o
 801fa590:collect_save_open_init
@@ -384,6 +391,7 @@
 8014ca2c:daNpcT_onEvtBit
 8014caac:daNpcT_chkEvtBit
 80155634:daNpcF_chkEvtBit
+8014a224:evtChange
 
 //resource.o
 802a9490:parseCharacter_1Byte
@@ -463,3 +471,13 @@
 
 // d_gameover.o
 8019b40c:dispWait_init
+
+// d_shop_system.o
+80199e28:seq_decide_yes
+801975dc:offFlag
+8019a4f4:setSoldOutItemHide
+8019a344:setSeq
+8019a354:setSoldOutFlag
+
+// f_pc_executor.o
+8002139c:fpcEx_IsExist

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -317,6 +317,7 @@
 
 // Z2SeqMgr.o
 802B4EB0:startBattleBgm
+802b3eac:checkBgmIDPlaying
 
 // Z2SoundMgr.o
 802A9EE8:startSound
@@ -459,3 +460,6 @@
 
 // f_op_actor_iter.o
 800197F8:fopAcIt_Judge
+
+// d_gameover.o
+8019b40c:dispWait_init

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -76,7 +76,7 @@
 800429D4:skipper
 
 // d_event_manager.o
-80047758:getEventIdx
+80047758:getEventIdx3
 
 // DynamicLink.o
 80262660:DynamicModuleControl_ct

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -75,6 +75,9 @@
 80042778:defaultSkipStb
 800429D4:skipper
 
+// d_event_manager.o
+80047758:getEventIdx
+
 // DynamicLink.o
 80262660:DynamicModuleControl_ct
 80262C5C:do_link
@@ -97,6 +100,7 @@
 80019AA8:CreateAppend
 80019D98:fopAcM_create
 8001bb14:fopAcM_getTalkEventPartner
+8001b5e4:fopAcM_orderChangeEventId
 
 // f_op_msg_mng.o
 8001fe84:fopMsgM_messageSet
@@ -133,7 +137,6 @@
 800d29d4:checkDownAttackState
 800c77f4:procCoMetamorphoseInit
 80115c20:checkEventRun
-803DCE54:linkStatus
 800e251c:checkBootsMoveAnime
 80119d98:procCoTalkInit
 800d8f3c:procDamageInit
@@ -142,6 +145,7 @@
 801181a0:setGetItemFace
 800d96dc:procCoLargeDamageInit
 8011ac28:procCoGetItem
+8011a798:procCoGetItemInit
 800cffa4:dComIfGp_setItemLifeCount
 800be3e4:checkRestartRoom
 8011f9ec:checkWarpStart
@@ -342,7 +346,6 @@
 
 //d_meter2_info.o
 80430188:g_meter2_info
-804301A4:wZButtonPtr
 8021e0c4:resetMiniGameItem
 
 //d_meter2_draw.o

--- a/GameCube/include/asm.h
+++ b/GameCube/include/asm.h
@@ -97,6 +97,10 @@ namespace mod::assembly
         void asmReplaceGWolfWithItem(void);
         bool handleReplaceGWolfWithItem(const int16_t* l_delFlag, void* daNpcGWolf);
 
+        // d_a_obj_master_sword.o
+        void asmGiveMasterSwordItems();
+        void handleGiveMasterSwordItems();
+
         // vi.o
         void asmCallCodehandler();
 

--- a/GameCube/include/asm.h
+++ b/GameCube/include/asm.h
@@ -32,7 +32,7 @@
 // 0xBC is offset to the text section relative to the start of the decompressed
 // REL. 0x4E4 is offset to Wait function relative to the start of the text
 // section (as seen on line 14 of d_a_obj_Lv5Key.map).
-#define d_a_obj_Lv5Key__Wait_offset 0xBC + 0x4E4
+#define d_a_obj_Lv5Key__Wait_offset (0xBC + 0x4E4)
 
 namespace mod::assembly
 {

--- a/GameCube/include/events.h
+++ b/GameCube/include/events.h
@@ -153,6 +153,7 @@ namespace mod::events
     uint16_t getPauseRupeeMax(libtp::tp::d_save::dSv_player_status_a_c* plyrStatus);
     uint32_t autoMashThroughText(libtp::tp::m_do_controller_pad::CPadInfo* padInfo);
     void* handleTransformAnywhere(libtp::tp::f_op_actor_iter::fopAcIt_JudgeFunc unk1, void* unk2);
+    bool checkValidTransformAnywhere();
 
     void performStaticASMReplacement(uint32_t memoryOffset, uint32_t value);
 

--- a/GameCube/include/events.h
+++ b/GameCube/include/events.h
@@ -39,6 +39,8 @@ namespace mod::events
     extern libtp::tp::dzx::ACTR ForestGWolfActr;
     extern libtp::tp::dzx::ACTR ImpPoeActr;
     extern libtp::tp::dzx::ACTR CampBoarActr;
+    extern libtp::tp::dzx::ACTR KakShopSlot2Actr;
+    extern libtp::tp::dzx::ACTR SignActr;
 
     extern uint8_t timeChange;
 
@@ -149,7 +151,7 @@ namespace mod::events
     void proc_onDungeonItem(libtp::tp::d_save::dSv_memBit_c* memBitPtr, const int32_t memBit);
 
     void loadCustomActors();
-    void loadCustomRoomActors();
+    void loadCustomRoomActors(rando::Randomizer* randomizer);
     void loadCustomRoomSCOBs();
     void handleQuickTransform();
     void handleTimeOfDayChange();

--- a/GameCube/include/events.h
+++ b/GameCube/include/events.h
@@ -41,6 +41,7 @@ namespace mod::events
     extern libtp::tp::dzx::ACTR CampBoarActr;
     extern libtp::tp::dzx::ACTR KakShopSlot2Actr;
     extern libtp::tp::dzx::ACTR SignActr;
+    extern libtp::tp::dzx::ACTR MstrSrdActr;
 
     extern uint8_t timeChange;
 

--- a/GameCube/include/game_patch/game_patch.h
+++ b/GameCube/include/game_patch/game_patch.h
@@ -176,6 +176,7 @@ namespace mod::game_patch
     uint32_t _05_getCustomMsgColor(uint8_t colorId);
     const char* _05_getMsgById(uint32_t msgId);
     const char* _05_getMsgById(uint32_t msgId, uint16_t* msgSizeOut);
+    const char* _05_getSpecialMsgById(uint32_t msgId);
     const char** _05_replaceMessageString(const char** text);
 
     // 06 - Function definitions for assembly patches

--- a/GameCube/include/game_patch/game_patch.h
+++ b/GameCube/include/game_patch/game_patch.h
@@ -118,6 +118,7 @@ namespace mod::game_patch
     void _02_firstFusedShadowItemFunc();
     void _02_secondFusedShadowItemFunc();
     void _02_thirdFusedShadowItemFunc();
+    void _02_firstMirrorShardItemFunc();
     void _02_secondMirrorShardItemFunc();
     void _02_thirdMirrorShardItemFunc();
     void _02_fourthMirrorShardItemFunc();
@@ -140,6 +141,7 @@ namespace mod::game_patch
     int32_t _02_firstFusedShadowItemGetCheck();
     int32_t _02_secondFusedShadowItemGetCheck();
     int32_t _02_thirdFusedShadowItemGetCheck();
+    int32_t _02_firstMirrorShardItemGetCheck();
     int32_t _02_secondMirrorShardItemGetCheck();
     int32_t _02_thirdMirrorShardItemGetCheck();
     int32_t _02_fourthMirrorShardItemGetCheck();

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -29,6 +29,9 @@
 #include "tp/d_meter2_info.h"
 #include "tp/d_menu_fmap2D.h"
 #include "tp/d_gameover.h"
+#include "tp/d_shop_system.h"
+#include "tp/f_op_actor.h"
+#include "tp/d_msg_flow.h"
 
 #ifdef TP_EU
 #include "tp/d_s_logo.h"
@@ -349,6 +352,22 @@ namespace mod
     int32_t handle_event017(void* messageFlow, void* nodeEvent, void* actrPtr);
     extern int32_t (*return_event017)(void* messageFlow, void* nodeEvent, void* actrPtr);
 
+    int32_t handle_doFlow(libtp::tp::d_msg_flow::dMsgFlow* msgFlow,
+                          libtp::tp::f_op_actor::fopAc_ac_c* actrPtr,
+                          libtp::tp::f_op_actor::fopAc_ac_c** actrValue,
+                          int32_t i_flow);
+    extern int32_t (*return_doFlow)(libtp::tp::d_msg_flow::dMsgFlow* msgFlow,
+                                    libtp::tp::f_op_actor::fopAc_ac_c* actrPtr,
+                                    libtp::tp::f_op_actor::fopAc_ac_c** actrValue,
+                                    int32_t i_flow);
+
+    int32_t handle_setNormalMsg(libtp::tp::d_msg_flow::dMsgFlow* msgFlow,
+                                void* flowNode,
+                                libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);
+    extern int32_t (*return_setNormalMsg)(libtp::tp::d_msg_flow::dMsgFlow* msgFlow,
+                                          void* flowNode,
+                                          libtp::tp::f_op_actor::fopAc_ac_c* actrPtr);
+
     // Save flag functions
     bool handle_isDungeonItem(libtp::tp::d_save::dSv_memBit_c* memBitPtr, const int32_t memBit);
     extern bool (*return_isDungeonItem)(libtp::tp::d_save::dSv_memBit_c* memBitPtr, const int32_t memBit);
@@ -462,5 +481,13 @@ namespace mod
     // Game Over functions
     void handle_dispWait_init(libtp::tp::d_gameover::dGameOver* ptr);
     extern void (*return_dispWait_init)(libtp::tp::d_gameover::dGameOver* ptr);
+
+    // Shop Functions
+    int32_t handle_seq_decide_yes(libtp::tp::d_shop_system::dShopSystem* shopPtr,
+                                  libtp::tp::f_op_actor::fopAc_ac_c* actor,
+                                  void* msgFlow);
+    extern int32_t (*return_seq_decide_yes)(libtp::tp::d_shop_system::dShopSystem* shopPtr,
+                                            libtp::tp::f_op_actor::fopAc_ac_c* actor,
+                                            void* msgFlow);
 } // namespace mod
 #endif

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -73,10 +73,12 @@ namespace mod
     extern const char* m_DonationText;
 
     // Variables
-    extern uint8_t* m_MsgTableInfo; // Custom message string data
+    extern uint8_t* m_MsgTableInfo;     // Custom message string data
+    extern uint8_t* m_HintMsgTableInfo; // Custom message string data
     extern libtp::tp::J2DPicture::J2DPicture* bgWindow;
     extern uint16_t lastButtonInput;
-    extern uint16_t m_TotalMsgEntries; // Number of currently loaded custom string
+    extern uint16_t m_TotalMsgEntries;     // Number of currently loaded custom string
+    extern uint16_t m_TotalHintMsgEntries; // Number of currently loaded custom string
     extern bool roomReloadingState;
     extern bool consoleState;
     extern uint8_t gameState;

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -21,12 +21,14 @@
 #include "tp/d_stage.h"
 #include "tp/control.h"
 #include "Z2AudioLib/Z2SceneMgr.h"
+#include "Z2AudioLib/Z2SeqMgr.h"
 #include "events.h"
 #include "tp/d_resource.h"
 #include "tp/JKRMemArchive.h"
 #include "tp/m_Do_dvd_thread.h"
 #include "tp/d_meter2_info.h"
 #include "tp/d_menu_fmap2D.h"
+#include "tp/d_gameover.h"
 
 #ifdef TP_EU
 #include "tp/d_s_logo.h"
@@ -430,11 +432,13 @@ namespace mod
                                       bool param_7);
 
     void handle_startSound(void* soungMgr, libtp::z2audiolib::z2scenemgr::JAISoundID soundId, void* soundHandle, void* pos);
-
     extern void (*return_startSound)(void* soundMgr,
                                      libtp::z2audiolib::z2scenemgr::JAISoundID soundId,
                                      void* soundHandle,
                                      void* pos);
+
+    bool handle_checkBgmIDPlaying(libtp::z2audiolib::z2seqmgr::Z2SeqMgr* seqMgr, uint32_t sfx_id);
+    extern bool (*return_checkBgmIDPlaying)(libtp::z2audiolib::z2seqmgr::Z2SeqMgr* seqMgr, uint32_t sfx_id);
 
     // Title Screen functions
     void* handle_dScnLogo_c_dt(void* dScnLogo_c, int16_t bFreeThis);
@@ -454,5 +458,9 @@ namespace mod
     // d_meter functions
     void handle_resetMiniGameItem(libtp::tp::d_meter2_info::G_Meter2_Info* gMeter2InfoPtr, bool minigameFlag);
     extern void (*return_resetMiniGameItem)(libtp::tp::d_meter2_info::G_Meter2_Info* gMeter2InfoPtr, bool minigameFlag);
+
+    // Game Over functions
+    void handle_dispWait_init(libtp::tp::d_gameover::dGameOver* ptr);
+    extern void (*return_dispWait_init)(libtp::tp::d_gameover::dGameOver* ptr);
 } // namespace mod
 #endif

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -95,6 +95,7 @@ namespace mod
     extern bool transformAnywhereEnabled;
     extern uint8_t damageMultiplier;
     extern bool bonksDoDamage;
+    extern bool giveItemToPlayer;
 
 #ifdef TP_EU
     extern libtp::tp::d_s_logo::Languages currentLanguage;
@@ -427,6 +428,9 @@ namespace mod
 
     float handle_damageMagnification(libtp::tp::d_a_alink::daAlink* daALink, int32_t param_1, int32_t param_2);
     extern float (*return_damageMagnification)(libtp::tp::d_a_alink::daAlink* daALink, int32_t param_1, int32_t param_2);
+
+    void handle_procCoGetItemInit(libtp::tp::d_a_alink::daAlink* linkActrPtr);
+    extern void (*return_procCoGetItemInit)(libtp::tp::d_a_alink::daAlink* linkActrPtr);
 
     // Audio functions
     void handle_loadSeWave(void* Z2SceneMgr, uint32_t waveID);

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -429,8 +429,8 @@ namespace mod
     float handle_damageMagnification(libtp::tp::d_a_alink::daAlink* daALink, int32_t param_1, int32_t param_2);
     extern float (*return_damageMagnification)(libtp::tp::d_a_alink::daAlink* daALink, int32_t param_1, int32_t param_2);
 
-    void handle_procCoGetItemInit(libtp::tp::d_a_alink::daAlink* linkActrPtr);
-    extern void (*return_procCoGetItemInit)(libtp::tp::d_a_alink::daAlink* linkActrPtr);
+    int32_t handle_procCoGetItemInit(libtp::tp::d_a_alink::daAlink* linkActrPtr);
+    extern int32_t (*return_procCoGetItemInit)(libtp::tp::d_a_alink::daAlink* linkActrPtr);
 
     // Audio functions
     void handle_loadSeWave(void* Z2SceneMgr, uint32_t waveID);

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -165,31 +165,29 @@ namespace mod
                                                int32_t unk3,
                                                void* unk4);
 
-    /*
-    void handle_dComIfGp_setNextStage( const char* stage,
-                                       int16_t point,
-                                       int8_t roomNo,
-                                       int8_t layer,
-                                       float lastSpeed,
-                                       uint32_t lastMode,
-                                       int32_t setPoint,
-                                       int8_t wipe,
-                                       int16_t lastAngle,
-                                       int32_t param_9,
-                                       int32_t wipSpeedT );
+    void handle_dComIfGp_setNextStage(const char* stage,
+                                      int16_t point,
+                                      int8_t roomNo,
+                                      int8_t layer,
+                                      float lastSpeed,
+                                      uint32_t lastMode,
+                                      int32_t setPoint,
+                                      int8_t wipe,
+                                      int16_t lastAngle,
+                                      int32_t param_9,
+                                      int32_t wipSpeedT);
 
-    extern void ( *return_dComIfGp_setNextStage )( const char* stage,
-                                                   int16_t point,
-                                                   int8_t roomNo,
-                                                   int8_t layer,
-                                                   float lastSpeed,
-                                                   uint32_t lastMode,
-                                                   int32_t setPoint,
-                                                   int8_t wipe,
-                                                   int16_t lastAngle,
-                                                   int32_t param_9,
-                                                   int32_t wipSpeedT );
-    */
+    extern void (*return_dComIfGp_setNextStage)(const char* stage,
+                                                int16_t point,
+                                                int8_t roomNo,
+                                                int8_t layer,
+                                                float lastSpeed,
+                                                uint32_t lastMode,
+                                                int32_t setPoint,
+                                                int8_t wipe,
+                                                int16_t lastAngle,
+                                                int32_t param_9,
+                                                int32_t wipSpeedT);
 
     int32_t handle_tgscInfoInit(void* stageDt, void* i_data, int32_t entryNum, void* param_3);
     extern int32_t (*return_tgscInfoInit)(void* stageDt, void* i_data, int32_t entryNum, void* param_3);

--- a/GameCube/include/rando/customItems.h
+++ b/GameCube/include/rando/customItems.h
@@ -21,6 +21,7 @@ namespace mod::rando::customItems
         Foolish_Item_3 = 0x15,                    // Custom Item added for the Randomizer.
         Foolish_Item_4 = 0x4D,                    // Custom Item added for the Randomizer.
         Foolish_Item_5 = 0x4E,                    // Custom Item added for the Randomizer.
+        Mirror_Piece_1 = 0x53,                    // Custom Item added for the Randomizer
         Foolish_Item_6 = 0x57,                    // Custom Item added for the Randomizer.
         Forest_Temple_Small_Key = 0x85,           // Custom Item added for the Randomizer.
         Goron_Mines_Small_Key = 0x86,             // Custom Item added for the Randomizer.

--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -56,14 +56,15 @@ namespace mod::rando
         /* 0x40 */ entryInfo skyCharacterCheckInfo;
         /* 0x44 */ entryInfo shopItemCheckInfo;
         /* 0x48 */ entryInfo startingItemInfo;
-        /* 0x4C */ uint16_t bgmHeaderOffset;
-        /* 0x4E */ uint16_t clr0Offset;
-        /* 0x50 */ uint8_t transformAnywhere;
-        /* 0x51 */ uint8_t quickTransform;
-        /* 0x52 */ uint8_t castleRequirements;
-        /* 0x53 */ uint8_t palaceRequirements;
-        /* 0x54 */ uint8_t mapClearBits;
-        /* 0x55 */ uint8_t padding[3];
+        /* 0x4C */ entryInfo EntranceTableInfo;
+        /* 0x50 */ uint16_t bgmHeaderOffset;
+        /* 0x52 */ uint16_t clr0Offset;
+        /* 0x54 */ uint8_t transformAnywhere;
+        /* 0x55 */ uint8_t quickTransform;
+        /* 0x56 */ uint8_t castleRequirements;
+        /* 0x57 */ uint8_t palaceRequirements;
+        /* 0x58 */ uint8_t mapClearBits;
+        /* 0x59 */ uint8_t padding[3];
     } __attribute__((__packed__));
 
     // Minimum amount of data needed for keeping track of a seed
@@ -302,6 +303,20 @@ namespace mod::rando
         int16_t flag;        // Flag associated with the current golden wolf
         uint8_t markerFlag;  // Flag associated with the current golden wolf's marker on the map
     };
+
+    struct ShuffledEntrance
+    {
+        uint8_t origStageIDX;
+        uint8_t origRoomIDX;
+        uint8_t origSpawn;
+        uint8_t origType;
+        uint16_t origParams;
+        uint8_t newStageIDX;
+        uint8_t newRoomIDX;
+        uint8_t newSpawn;
+        uint8_t newType;
+        uint16_t newParams;
+    } __attribute__((__packed__));
 
     extern int32_t lookupTable[DvdEntryNumIdSize];
 

--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -70,7 +70,7 @@ namespace mod::rando
         /* 0x60 */ uint8_t mapClearBits;
         /* 0x61 */ uint8_t damageMagnification;
         /* 0x62 */ uint8_t bonksDoDamage;
-        /* 0x63 */ uint8_t padding;
+        /* 0x63 */ uint8_t startingTimeOfDay;
     } __attribute__((__packed__));
 
     // Minimum amount of data needed for keeping track of a seed
@@ -224,21 +224,12 @@ namespace mod::rando
         uint8_t flag;     // The unique identifier used to disinguish between checks in the same room.
     } __attribute__((__packed__));
 
-    struct CustomMessageEntryInfo
-    {
-        uint8_t language;
-        uint8_t padding;
-        uint16_t totalEntries;
-        uint32_t msgTableSize;
-        uint32_t msgIdTableOffset;
-    } __attribute__((__packed__));
-
     struct CustomMessageHeaderInfo
     {
         uint16_t headerSize;
-        uint8_t totalLanguages;
-        uint8_t padding[1];
-        CustomMessageEntryInfo entry[]; // Size is totalLanguages
+        uint16_t totalEntries;
+        uint32_t msgTableSize;
+        uint32_t msgIdTableOffset;
     } __attribute__((__packed__));
 
     struct CustomMessageData
@@ -304,6 +295,14 @@ namespace mod::rando
         PoT_Fused_Shadows = 1,
         PoT_Mirror_Shards,
         PoT_Vanilla
+    };
+
+    enum StartingTimeOfDay : uint8_t
+    {
+        Morning = 0,
+        Noon = 1,
+        Evening = 2,
+        Night = 3
     };
 
     struct RawRGBTable

--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -59,14 +59,16 @@ namespace mod::rando
         /* 0x48 */ entryInfo startingItemInfo;
         /* 0x4C */ uint16_t bgmHeaderOffset;
         /* 0x4E */ uint16_t clr0Offset;
-        /* 0x50 */ uint8_t transformAnywhere;
-        /* 0x51 */ uint8_t quickTransform;
-        /* 0x52 */ uint8_t castleRequirements;
-        /* 0x53 */ uint8_t palaceRequirements;
-        /* 0x54 */ uint8_t mapClearBits;
-        /* 0x55 */ uint8_t damageMagnification;
-        /* 0x56 */ uint8_t bonksDoDamage;
-        /* 0x57 */ uint8_t padding;
+        /* 0x50 */ uint16_t customTextHeaderSize;
+        /* 0x52 */ uint16_t customTextHeaderOffset;
+        /* 0x54 */ uint8_t transformAnywhere;
+        /* 0x55 */ uint8_t quickTransform;
+        /* 0x56 */ uint8_t castleRequirements;
+        /* 0x57 */ uint8_t palaceRequirements;
+        /* 0x58 */ uint8_t mapClearBits;
+        /* 0x59 */ uint8_t damageMagnification;
+        /* 0x5A */ uint8_t bonksDoDamage;
+        /* 0x5B */ uint8_t padding;
     } __attribute__((__packed__));
 
     // Minimum amount of data needed for keeping track of a seed
@@ -214,7 +216,7 @@ namespace mod::rando
     struct CustomMessageEntryInfo
     {
         uint8_t language;
-        uint8_t padding[1];
+        uint8_t padding;
         uint16_t totalEntries;
         uint32_t msgTableSize;
         uint32_t msgIdTableOffset;
@@ -226,6 +228,13 @@ namespace mod::rando
         uint8_t totalLanguages;
         uint8_t padding[1];
         CustomMessageEntryInfo entry[]; // Size is totalLanguages
+    } __attribute__((__packed__));
+
+    struct CustomMessageData
+    {
+        uint8_t stageIDX;
+        uint8_t roomIDX;
+        uint16_t msgID;
     } __attribute__((__packed__));
 
     struct CLR0Header

--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -348,13 +348,11 @@ namespace mod::rando
         uint8_t origStageIDX;
         uint8_t origRoomIDX;
         uint8_t origSpawn;
-        uint8_t origType;
-        uint16_t origParams;
+        int8_t origState;
         uint8_t newStageIDX;
         uint8_t newRoomIDX;
         uint8_t newSpawn;
-        uint8_t newType;
-        uint16_t newParams;
+        int8_t newState;
     } __attribute__((__packed__));
 
     extern int32_t lookupTable[DvdEntryNumIdSize];

--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -56,20 +56,21 @@ namespace mod::rando
         /* 0x3C */ entryInfo bugRewardCheckInfo;
         /* 0x40 */ entryInfo skyCharacterCheckInfo;
         /* 0x44 */ entryInfo shopItemCheckInfo;
-        /* 0x48 */ entryInfo startingItemInfo;
-        /* 0x4C */ entryInfo EntranceTableInfo;
-        /* 0x50 */ uint16_t bgmHeaderOffset;
-        /* 0x52 */ uint16_t clr0Offset;
-        /* 0x54 */ uint16_t customTextHeaderSize;
-        /* 0x56 */ uint16_t customTextHeaderOffset;
-        /* 0x58 */ uint8_t transformAnywhere;
-        /* 0x59 */ uint8_t quickTransform;
-        /* 0x5A */ uint8_t castleRequirements;
-        /* 0x5B */ uint8_t palaceRequirements;
-        /* 0x5C */ uint8_t mapClearBits;
-        /* 0x5D */ uint8_t damageMagnification;
-        /* 0x5E */ uint8_t bonksDoDamage;
-        /* 0x5F */ uint8_t padding;
+        /* 0x48 */ entryInfo eventItemCheckInfo;
+        /* 0x4C */ entryInfo startingItemInfo;
+        /* 0x50 */ entryInfo EntranceTableInfo;
+        /* 0x54 */ uint16_t bgmHeaderOffset;
+        /* 0x56 */ uint16_t clr0Offset;
+        /* 0x58 */ uint16_t customTextHeaderSize;
+        /* 0x5A */ uint16_t customTextHeaderOffset;
+        /* 0x5C */ uint8_t transformAnywhere;
+        /* 0x5D */ uint8_t quickTransform;
+        /* 0x5E */ uint8_t castleRequirements;
+        /* 0x5F */ uint8_t palaceRequirements;
+        /* 0x60 */ uint8_t mapClearBits;
+        /* 0x61 */ uint8_t damageMagnification;
+        /* 0x62 */ uint8_t bonksDoDamage;
+        /* 0x63 */ uint8_t padding;
     } __attribute__((__packed__));
 
     // Minimum amount of data needed for keeping track of a seed
@@ -214,6 +215,15 @@ namespace mod::rando
         uint8_t roomID;    // The room that the Owl Statue is located in.
     } __attribute__((__packed__));
 
+    // These items are given either during cutscenes or at a specific time.
+    struct EventItem
+    {
+        uint8_t itemID;   // The item to be given.
+        uint8_t stageIDX; // The stage that the event is in.
+        uint8_t roomID;   // The room that the event is in.
+        uint8_t flag;     // The unique identifier used to disinguish between checks in the same room.
+    } __attribute__((__packed__));
+
     struct CustomMessageEntryInfo
     {
         uint8_t language;
@@ -277,6 +287,23 @@ namespace mod::rando
         XBtn,
         YBtn,
         ZBtn
+    };
+
+    enum CastleEntryRequirements : uint8_t
+    {
+        HC_Open = 0,
+        HC_Fused_Shadows = 1,
+        HC_Mirror_Shards,
+        HC_All_Dungeons,
+        HC_Vanilla
+    };
+
+    enum PalaceEntryRequirements : uint8_t
+    {
+        PoT_Open = 0,
+        PoT_Fused_Shadows = 1,
+        PoT_Mirror_Shards,
+        PoT_Vanilla
     };
 
     struct RawRGBTable

--- a/GameCube/include/rando/randomizer.h
+++ b/GameCube/include/rando/randomizer.h
@@ -34,12 +34,14 @@ namespace mod::rando
         int32_t getPoeItem(uint8_t flag);
         uint8_t getSkyCharacter();
         uint8_t getBossItem(int32_t originalItem);
+        int8_t getEventItem(uint8_t flag);
         void overrideARC(uint32_t fileAddr, FileDirectory fileDirectory, int32_t roomNo);
         void overrideObjectARC(libtp::tp::d_resource::dRes_info_c* resourcePtr, const char* fileName);
         void overrideEventARC();
         uint8_t overrideBugReward(uint8_t bugID);
         void getHiddenSkillItem(void* daNpcGWolfPtr, int16_t flag, uint32_t markerFlag);
         void replaceWolfLockDomeColor(libtp::tp::d_a_alink::daAlink* linkActrPtr);
+        void addItemToEventQueue(uint8_t itemToAdd);
 
         // NOTE: This function returns dynamic memory
         BMDEntry* generateBmdEntries(mod::rando::DvdEntryNumId arcIndex, uint32_t numEntries);

--- a/GameCube/include/rando/seed.h
+++ b/GameCube/include/rando/seed.h
@@ -38,6 +38,7 @@ namespace mod::rando
         SkyCharacter* m_SkyBookChecks = nullptr;
         ObjectArchiveReplacement* m_ObjectArcReplacements = nullptr;
         ShuffledEntrance* m_ShuffledEntrances = nullptr;
+        EventItem* m_EventChecks = nullptr;
 
         const char* m_RequiredDungeons = nullptr; // Displayed when reading the sign in front of Link's house
 
@@ -55,6 +56,7 @@ namespace mod::rando
         uint16_t m_numHiddenSkillChecks = 0;
         uint16_t m_numBugRewardChecks = 0;
         uint16_t m_numSkyBookChecks = 0;
+        uint16_t m_numLoadedEventChecks = 0;
         uint16_t m_numLoadedObjectArcReplacements = 0;
         uint16_t m_numShuffledEntrances = 0;
 
@@ -151,6 +153,7 @@ namespace mod::rando
         void LoadSkyCharacter(uint8_t stageIDX);
         void LoadHiddenSkill();
         void LoadBugReward();
+        void LoadEventChecks(uint8_t stageIDX);
         bool loadCustomText(uint8_t* data);
     };
 } // namespace mod::rando

--- a/GameCube/include/rando/seed.h
+++ b/GameCube/include/rando/seed.h
@@ -148,6 +148,7 @@ namespace mod::rando
         void LoadSkyCharacter(uint8_t stageIDX);
         void LoadHiddenSkill();
         void LoadBugReward();
+        bool loadCustomText(uint8_t* data);
     };
 } // namespace mod::rando
 #endif

--- a/GameCube/include/rando/seed.h
+++ b/GameCube/include/rando/seed.h
@@ -37,6 +37,7 @@ namespace mod::rando
         BugReward* m_BugRewardChecks = nullptr;
         SkyCharacter* m_SkyBookChecks = nullptr;
         ObjectArchiveReplacement* m_ObjectArcReplacements = nullptr;
+        ShuffledEntrance* m_ShuffledEntrances = nullptr;
 
         const char* m_RequiredDungeons = nullptr; // Displayed when reading the sign in front of Link's house
 
@@ -55,6 +56,7 @@ namespace mod::rando
         uint16_t m_numBugRewardChecks = 0;
         uint16_t m_numSkyBookChecks = 0;
         uint16_t m_numLoadedObjectArcReplacements = 0;
+        uint16_t m_numShuffledEntrances = 0;
 
         uint16_t m_PatchesApplied = 0;
         uint16_t m_EventFlagsModified = 0;
@@ -127,6 +129,7 @@ namespace mod::rando
         void applyOneTimePatches(bool set);
 
         void loadShopModels();
+        void loadShuffledEntrances();
 
        private:
         uint8_t* m_GCIData = nullptr; // GCI Data including header

--- a/GameCube/include/user_patch/05_newFileFunctions.h
+++ b/GameCube/include/user_patch/05_newFileFunctions.h
@@ -25,6 +25,7 @@ namespace mod::user_patch
     void setInstantText(rando::Randomizer* randomizer, bool set);
     void setMapRegionBits(rando::Randomizer* randomizer, bool set);
     void increaseSpinnerVelocity(rando::Randomizer* randomizer, bool set);
+    void skipMajorCutscenes(rando::Randomizer* randomizer, bool set);
 } // namespace mod::user_patch
 
 #endif

--- a/GameCube/include/user_patch/user_patch.h
+++ b/GameCube/include/user_patch/user_patch.h
@@ -23,7 +23,7 @@ namespace mod::user_patch
 
     // Available Game patches accessible by index
     extern GamePatch volatilePatches[6];
-    extern GamePatch oneTimePatches[6];
+    extern GamePatch oneTimePatches[7];
 
 } // namespace mod::user_patch
 #endif

--- a/GameCube/source/asm/giveMasterSwordItems.s
+++ b/GameCube/source/asm/giveMasterSwordItems.s
@@ -1,0 +1,31 @@
+.global asmGiveMasterSwordItems
+.hidden asmGiveMasterSwordItems
+
+asmGiveMasterSwordItems:
+# Push stack
+stwu %sp,-0x10(%sp)
+mflr %r0
+stw %r0,0x14(%sp)
+
+# Backup important register values
+stw %r4,0x8(%sp)
+stw %r26,0xC(%sp)
+
+bl handleGiveMasterSwordItems
+
+# Restore important register values
+lwz %r26,0xC(%sp)
+lwz %r4,0x8(%sp)
+
+# Clear the current actor status for the Master Sword actor since we set the flag to delete it in the handle function.
+li %r3, 0x0
+sth %r3, 0x49E(%r26)
+
+# Pop stack
+lwz %r0,0x14(%sp)
+mtlr %r0
+addi %sp,%sp,0x10
+
+# Restore the original instruction
+li %r3,47
+blr

--- a/GameCube/source/asm/handler.cpp
+++ b/GameCube/source/asm/handler.cpp
@@ -12,6 +12,7 @@
 #include "data/items.h"
 #include "data/flags.h"
 #include "tp/d_a_npc.h"
+#include "game_patch/game_patch.h"
 
 namespace mod::assembly
 {
@@ -124,6 +125,25 @@ namespace mod::assembly
         }
 
         return flagIsSet;
+    }
+
+    void handleGiveMasterSwordItems()
+    {
+        using namespace libtp::data;
+        // Give the player the Master Sword replacement
+        uint8_t itemToGive = randomizer->getEventItem(items::Master_Sword);
+        itemToGive = game_patch::_04_verifyProgressiveItem(randomizer, itemToGive);
+        randomizer->addItemToEventQueue(itemToGive);
+
+        // Give the player the Shadow Crystal replacement
+        itemToGive = randomizer->getEventItem(items::Shadow_Crystal);
+        itemToGive = game_patch::_04_verifyProgressiveItem(randomizer, itemToGive);
+        randomizer->addItemToEventQueue(itemToGive);
+
+        // Set the local event flag to make the sword de-spawn and set the save file event flag.
+        libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.events, 0x820);
+
+        return;
     }
 
 #ifdef TP_JP

--- a/GameCube/source/asm/handler.cpp
+++ b/GameCube/source/asm/handler.cpp
@@ -142,6 +142,7 @@ namespace mod::assembly
 
         // Set the local event flag to make the sword de-spawn and set the save file event flag.
         libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.events, 0x820);
+        libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags, 0x2120);
 
         return;
     }

--- a/GameCube/source/asm/handler.cpp
+++ b/GameCube/source/asm/handler.cpp
@@ -77,7 +77,7 @@ namespace mod::assembly
     uint8_t handleShowReekfishPath(uint8_t scent)
     {
         if ((libtp::tp::d_a_alink::checkStageName(libtp::data::stage::allStages[libtp::data::stage::StageIDs::Snowpeak])) &&
-            libtp::tp::d_a_alink::dComIfGs_isEventBit(
+            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                 libtp::data::flags::GOT_REEKFISH_SCENT)) // If we are currently at Snowpeak and the flag for having
                                                          // smelled a Reekfish is set
         {
@@ -97,7 +97,7 @@ namespace mod::assembly
     bool handleCheck60PoeReward(uint8_t poeCount)
     {
         // Check if we are getting the 60 Poe Check and that we have already gotten the 20 Poe Check.
-        return ((poeCount >= 60) && libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::GOT_BOTTLE_FROM_JOVANI));
+        return ((poeCount >= 60) && libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::GOT_BOTTLE_FROM_JOVANI));
     }
 
     bool handleReplaceGWolfWithItem(const int16_t* l_delFlag, void* daNpcGWolf)
@@ -141,8 +141,8 @@ namespace mod::assembly
         randomizer->addItemToEventQueue(itemToGive);
 
         // Set the local event flag to make the sword de-spawn and set the save file event flag.
-        libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.events, 0x820);
-        libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags, 0x2120);
+        libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.mTmp, 0x820);
+        libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.mEvent, 0x2120);
 
         return;
     }

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -1166,10 +1166,10 @@ namespace mod::events
                 localSignActor.pos.x = -109203.461f;
                 localSignActor.pos.y = -7220.f;
                 localSignActor.pos.z = 33083.7344f;
-                localSignActor.rot[1] = static_cast<int16_t>(0x8556);
+                localSignActor.rot[1] = static_cast<int16_t>(0x6556);
                 tools::spawnActor(0, localSignActor);
 
-                if (roomIDX == 1)
+                if (roomIDX == 1) // needs to rotate left
                 {
                     localSignActor.pos.x = -324.1757f;
                     localSignActor.pos.y = -1627.872f;
@@ -1198,14 +1198,14 @@ namespace mod::events
                         localGanonBarrierActor.pos.z -= 270.f;
                         tools::spawnActor(7, localGanonBarrierActor);
                     }
-                    localSignActor.pos.x = -12275.1543f;
+                    localSignActor.pos.x = -12275.1543f; // needs to rotate left
                     localSignActor.pos.y = -1001.9508;
                     localSignActor.pos.z = 20293.6855f;
                     localSignActor.rot[1] = static_cast<int16_t>(0xD556);
                     tools::spawnActor(0, localSignActor);
                 }
 
-                if (roomIDX == 6)
+                if (roomIDX == 6) // needs to rotate left
                 {
                     localSignActor.pos.x = -46039.4922f;
                     localSignActor.pos.y = -9250.f;
@@ -1214,7 +1214,7 @@ namespace mod::events
                     tools::spawnActor(6, localSignActor);
                 }
 
-                if (roomIDX == 3)
+                if (roomIDX == 3) // nees to rotate left
                 {
                     localSignActor.pos.x = -10906.2344f;
                     localSignActor.pos.y = -3190.27808f;
@@ -1223,7 +1223,7 @@ namespace mod::events
                     tools::spawnActor(3, localSignActor);
                 }
 
-                if (roomIDX == 7)
+                if (roomIDX == 7) // neds to rotate left
                 {
                     localSignActor.pos.x = 29691.0742f;
                     localSignActor.pos.y = 661.668;
@@ -1232,7 +1232,7 @@ namespace mod::events
                     tools::spawnActor(7, localSignActor);
                 }
 
-                if (roomIDX == 10)
+                if (roomIDX == 10) // needs to rotate left
                 {
                     localSignActor.pos.x = -46711.957f;
                     localSignActor.pos.y = 268.4848f;
@@ -1241,7 +1241,7 @@ namespace mod::events
                     tools::spawnActor(10, localSignActor);
                 }
 
-                if (roomIDX == 13)
+                if (roomIDX == 13) // needs to rotate right
                 {
                     localSignActor.pos.x = -94678.8672f;
                     localSignActor.pos.y = -3900.f;
@@ -1261,11 +1261,11 @@ namespace mod::events
                     tools::spawnActor(6, ForestGWolfActr);
                 }
 
-                if ((roomIDX == 8) || (roomIDX == 4))
+                if (roomIDX == 4)
                 {
-                    localSignActor.pos.x = -16173.2764f;
-                    localSignActor.pos.y = -348.143036f;
-                    localSignActor.pos.z = -17432.4785f;
+                    localSignActor.pos.x = -12420.0508f;
+                    localSignActor.pos.y = -274.354553f;
+                    localSignActor.pos.z = -11469.2881f;
                     localSignActor.rot[1] = static_cast<int16_t>(0xD556);
                     tools::spawnActor(8, localSignActor);
                 }
@@ -1288,7 +1288,7 @@ namespace mod::events
                 localSignActor.pos.x = -2119.33057f;
                 localSignActor.pos.y = 260.f;
                 localSignActor.pos.z = -3915.6517f;
-                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556); // needs to rotate right
                 tools::spawnActor(1, localSignActor);
                 break;
             }
@@ -1299,7 +1299,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Kakariko_Village:
+            case StageIDs::Kakariko_Village: // needs to rotate right a lot
             {
                 localSignActor.pos.x = -6277.372f;
                 localSignActor.pos.y = 2850.f;
@@ -1309,7 +1309,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Ordon_Village:
+            case StageIDs::Ordon_Village: // needs to rotate left slightly
             {
                 localSignActor.pos.x = 687.89f;
                 localSignActor.pos.y = 800.f;
@@ -1321,11 +1321,11 @@ namespace mod::events
 
             case StageIDs::Sacred_Grove:
             {
-                localSignActor.pos.x = -8715.3418f;
-                localSignActor.pos.y = 2000.f;
-                localSignActor.pos.z = 4178.08252f;
+                localSignActor.pos.x = -1510.01062f;
+                localSignActor.pos.y = 1725.f;
+                localSignActor.pos.z = 7811.07715f;
                 localSignActor.rot[1] = static_cast<int16_t>(0xD556);
-                tools::spawnActor(3, localSignActor);
+                tools::spawnActor(1, localSignActor);
 
                 if (roomIDX == 1)
                 {
@@ -1334,7 +1334,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Kakariko_Graveyard:
+            case StageIDs::Kakariko_Graveyard: // needs to rotate left slightly
             {
                 localSignActor.pos.x = 21765.9863f;
                 localSignActor.pos.y = 500.f;
@@ -1344,7 +1344,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Death_Mountain:
+            case StageIDs::Death_Mountain: // needs to rotate right
             {
                 localSignActor.pos.x = -5459.5757f;
                 localSignActor.pos.y = 0.f;
@@ -1354,7 +1354,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Hidden_Village:
+            case StageIDs::Hidden_Village: // needs to rotate right
             {
                 localSignActor.pos.x = 5161.03f;
                 localSignActor.pos.y = 0.f;
@@ -1366,7 +1366,7 @@ namespace mod::events
 
             case StageIDs::Outside_Castle_Town:
             {
-                if (roomIDX == 8)
+                if (roomIDX == 8) // needs to rotate left
                 {
                     localSignActor.pos.x = -68194.2109f;
                     localSignActor.pos.y = -1050.f;
@@ -1374,7 +1374,7 @@ namespace mod::events
                     localSignActor.rot[1] = static_cast<int16_t>(0xD556);
                     tools::spawnActor(8, localSignActor);
                 }
-                else if (roomIDX == 16)
+                else if (roomIDX == 16) // needs to rotate right
                 {
                     localSignActor.pos.x = -51491.0234f;
                     localSignActor.pos.y = -5500.f;
@@ -1385,7 +1385,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Lake_Hylia_Long_Cave:
+            case StageIDs::Lake_Hylia_Long_Cave: // needs to make a 180
             {
                 localSignActor.pos.x = -1006.33252f;
                 localSignActor.pos.y = -1703.19995f;
@@ -1395,7 +1395,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Zoras_Domain:
+            case StageIDs::Zoras_Domain: // needs to rotate slightly right
             {
                 localSignActor.pos.x = -3981.957f;
                 localSignActor.pos.y = -2500.f;
@@ -1405,7 +1405,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Fishing_Pond:
+            case StageIDs::Fishing_Pond: // needs to rotate slightly left
             {
                 localSignActor.pos.x = -2921.2417f;
                 localSignActor.pos.y = 35.f;
@@ -1415,7 +1415,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Gerudo_Desert:
+            case StageIDs::Gerudo_Desert: // needs to rotate right
             {
                 localSignActor.pos.x = 20356.23f;
                 localSignActor.pos.y = 556.7;
@@ -1425,7 +1425,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Snowpeak:
+            case StageIDs::Snowpeak: // needs to rotate right a lot
             {
                 localSignActor.pos.x = 14804.874f;
                 localSignActor.pos.y = -14450.0908f;
@@ -1435,7 +1435,7 @@ namespace mod::events
                 break;
             }
 
-            case StageIDs::Cave_of_Ordeals:
+            case StageIDs::Cave_of_Ordeals: // needs to rotate just barely right
             {
                 localSignActor.pos.x = -1191.42f;
                 localSignActor.pos.y = 1100.f;

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -869,14 +869,15 @@ namespace mod::events
 
     int32_t proc_query022(void* unk1, void* unk2, int32_t unk3)
     {
+        using namespace libtp::data;
+        using namespace libtp::tp;
         // Check to see if currently in one of the Ordon interiors
-        if (libtp::tp::d_a_alink::checkStageName(
-                libtp::data::stage::allStages[libtp::data::stage::StageIDs::Ordon_Village_Interiors]))
+        if (d_a_alink::checkStageName(stage::allStages[stage::StageIDs::Ordon_Village_Interiors]))
         {
-            // Check to see if ckecking for the Iron Boots
+            // Check to see if checking for the Iron Boots
             const uint32_t item = *reinterpret_cast<uint16_t*>(reinterpret_cast<uint32_t>(unk2) + 0x4);
 
-            if (item == libtp::data::items::Iron_Boots)
+            if (item == items::Iron_Boots)
             {
                 // Return false so that the door in Bo's house can be opened without having the
                 // Iron Boots

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -41,25 +41,50 @@ namespace mod::events
     daObjLifeContainer_initActionOrderGetDemo_Def return_daObjLifeContainer_c__initActionOrderGetDemo = nullptr;
     daMidna_checkMetamorphoseEnableBase_Def daMidna_c__checkMetamorphoseEnableBase = nullptr;
 
+    // Custom Ganon Barrier to prevent the player from trying to enter Lanayru Twilight during Eldin Twilight
     libtp::tp::dzx::ACTR GanonBarrierActor =
         {"Obj_gb", 0x800F0601, 10778.207f, 3096.82666f, -62651.0078f, static_cast<int16_t>(-164), 0x4000, 0, 0xFFFF};
 
+    // Auru actor that is added to the Post-Cannon repair state of Lake Hylia
     libtp::tp::dzx::ACTR AuruActr =
         {"Rafrel", 0x00001D01, -116486.945f, -13860.f, 58533.0078f, 0, static_cast<int16_t>(0xCCCD), 0, 0xFFFF};
 
+    // item actor template
     libtp::tp::dzx::ACTR ItemActr =
         {"item", 0xF3FFFF04, -108290.086f, -18654.748f, 45935.2969f, 0, static_cast<int16_t>(0x1), 0x3F, 0xFFFF};
 
+    // Epona actor template
     libtp::tp::dzx::ACTR EponaActr = {"Horse", 0x00000F0D, -1200.f, 367.f, 6100.f, 0, -180, 0, 0xFFFF};
 
+    // Horse jump SCOB template
     libtp::tp::dzx::SCOB HorseJumpScob =
         {"Hjump", 0x044FFF02, 5600.f, -5680.f, 52055.f, 0, static_cast<int16_t>(0x4000), 0, 0xFFFF, 0x20, 0x2D, 0x2D, 0xFF};
 
+    // Golden Wolf actor placed in Faron Woods.
     libtp::tp::dzx::ACTR ForestGWolfActr = {"GWolf", 0x05FF01FF, -35178.f, 430.21f, -21503.6f, 0, -0x4000, 0xFF, 0xFFFF};
 
+    // Poe actor template
     libtp::tp::dzx::ACTR ImpPoeActr = {"E_hp", 0xFF031E00, 4531.19f, -30.f, 2631.961f, 0, 0, 0x0, 0xFFFF};
 
+    // Boar actor template
     libtp::tp::dzx::ACTR CampBoarActr = {"E_wb", 0xFFFFFFFF, 1650.f, 0.f, 1250.f, 0, static_cast<int16_t>(0xA000), 0x0, 0xFFFF};
+
+    // Custom shop sold out actors for shop checks. using actor template: 0x48 bytes in memory due to instructions
+    // Creating new actors uses less memory than modifying a template due to the amount of memory used by instructions.
+    // (0x28 vs 0x48 bytes)
+    libtp::tp::dzx::ACTR KakShopSlot2Actr =
+        {"TGSPITM", 0x02FFFFFF, -650.f, 450.f, -500.f, 0x147, static_cast<int16_t>(0x8000), 0x3AFF, 0xFFFF};
+
+    // Sign Actors
+    libtp::tp::dzx::ACTR SignActor = {"Obj_kn2",
+                                      0xFFFFFFFF,
+                                      -2088.f,
+                                      0.8535f,
+                                      7535.77f,
+                                      static_cast<int16_t>(0xFFFE), // Flow Node ID
+                                      static_cast<int16_t>(0xD556),
+                                      0,
+                                      0xFFFF};
 
     uint8_t timeChange = 0;
 
@@ -235,6 +260,9 @@ namespace mod::events
             case D_A_MG_ROD:
             {
                 libtp::patch::writeBranchBL(relPtrRaw + 0xB2B0, libtp::tp::d_item::execItemGet);
+
+                // Branch over rng check instructions from uki_main for 100% bottle guarantee
+                performStaticASMReplacement(relPtrRaw + 0xBFAC, ASM_BRANCH(0x18));
                 break;
             }
 
@@ -285,6 +313,7 @@ namespace mod::events
                                 break;
                             }
                             case items::Ordon_Sword:
+                            case customItems::Mirror_Piece_1:
                             case items::Mirror_Piece_2:
                             case items::Mirror_Piece_3:
                             case items::Mirror_Piece_4:
@@ -775,6 +804,7 @@ namespace mod::events
     {
         using namespace libtp::data::stage;
         using namespace libtp::data::items;
+        using namespace rando::customItems;
 
         if (!getCurrentSeed(randomizer))
         {
@@ -819,6 +849,7 @@ namespace mod::events
 
             case Master_Sword:
             case Master_Sword_Light:
+            case Mirror_Piece_1:
             case Mirror_Piece_2:
             case Mirror_Piece_3:
             case Mirror_Piece_4:
@@ -842,10 +873,12 @@ namespace mod::events
         }
 
         using namespace libtp::data::items;
+        using namespace rando::customItems;
 
         const uint32_t itemID = *reinterpret_cast<uint8_t*>(reinterpret_cast<uint32_t>(daDitem) + 0x92A);
         switch (itemID)
         {
+            case Mirror_Piece_1:
             case Mirror_Piece_2:
             case Mirror_Piece_3:
             case Mirror_Piece_4:
@@ -1028,70 +1061,425 @@ namespace mod::events
     void loadCustomActors()
     {
         using namespace libtp;
+        using namespace libtp::data::stage;
 
-        const auto stagesPtr = &data::stage::allStages[0];
-        if (tp::d_a_alink::checkStageName(stagesPtr[data::stage::StageIDs::Faron_Woods]))
+        const auto stagesPtr = &allStages[0];
+        if (tp::d_a_alink::checkStageName(stagesPtr[StageIDs::Faron_Woods]))
         {
             tools::spawnActor(0, EponaActr);
         }
-        else if ((tp::d_a_alink::checkStageName(stagesPtr[data::stage::StageIDs::Ordon_Village]) &&
-                  (libtp::tools::getCurrentRoomNo() == 0)))
+        else if (libtp::tools::playerIsInRoomStage(0, stagesPtr[libtp::data::stage::StageIDs::Ordon_Village]))
         {
-            libtp::tp::dzx::ACTR localEponaActor;
-            memcpy(&localEponaActor, &EponaActr, sizeof(libtp::tp::dzx::ACTR));
+            tp::dzx::ACTR localEponaActor;
+            memcpy(&localEponaActor, &EponaActr, sizeof(tp::dzx::ACTR));
 
             localEponaActor.parameters = 0x148;
             tools::spawnActor(0, localEponaActor);
         }
     }
 
-    void loadCustomRoomActors()
+    void loadCustomRoomActors(rando::Randomizer* randomizer)
     {
         using namespace libtp;
+        using namespace libtp::data::stage;
 
-        const auto stagesPtr = &data::stage::allStages[0];
-        if (tp::d_a_alink::checkStageName(stagesPtr[data::stage::StageIDs::Lake_Hylia]))
+        if (!getCurrentSeed(randomizer))
         {
-            if (libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::SKY_CANNON_REPAIRED))
+            return;
+        }
+
+        int32_t stageIDX = randomizer->m_Seed->m_StageIDX;
+        int32_t roomIDX = tools::getCurrentRoomNo();
+
+        tp::dzx::ACTR localSignActor;
+        memcpy(&localSignActor, &SignActor, sizeof(tp::dzx::ACTR));
+
+        switch (stageIDX)
+        {
+            case StageIDs::Lake_Hylia:
             {
-                // Manually spawn Auru if the Lake is in the Repaired Cannon state as his actor is not in the DZX for that
-                // layer.
-                tools::spawnActor(0, AuruActr);
+                if (libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::SKY_CANNON_REPAIRED))
+                {
+                    // Manually spawn Auru if the Lake is in the Repaired Cannon state as his actor is not in the DZX for that
+                    // layer.
+                    tools::spawnActor(0, AuruActr);
+                }
+
+                // Spawn a red rupee behind Fyer's house that allows the player to use his cannon to leave the lake which
+                // prevents a softlock.
+                tools::spawnActor(0, ItemActr);
+
+                localSignActor.pos.x = -109203.461f;
+                localSignActor.pos.y = -7220.f;
+                localSignActor.pos.z = 33083.7344f;
+                localSignActor.rot[1] = static_cast<int16_t>(0x8556);
+                tools::spawnActor(0, localSignActor);
+
+                if (roomIDX == 1)
+                {
+                    localSignActor.pos.x = -324.1757f;
+                    localSignActor.pos.y = -1627.872f;
+                    localSignActor.pos.z = 85.1628f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(1, localSignActor);
+                }
+                break;
             }
 
-            // Spawn a red rupee behind Fyer's house that allows the player to use his cannon to leave the lake which prevents a
-            // softlock.
-            tools::spawnActor(0, ItemActr);
-        }
-        else if (tp::d_a_alink::checkStageName(stagesPtr[data::stage::StageIDs::Hyrule_Field]) &&
-                 (!tp::d_save::isEventBit(&tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags,
-                                          data::flags::CLEARED_ELDIN_TWILIGHT)))
-        {
-            libtp::tp::dzx::ACTR localGanonBarrierActor;
-            memcpy(&localGanonBarrierActor, &GanonBarrierActor, sizeof(libtp::tp::dzx::ACTR));
+            case StageIDs::Hyrule_Field:
+            {
+                if (roomIDX == 0)
+                {
+                    if (!tp::d_save::isEventBit(&tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags,
+                                                data::flags::CLEARED_ELDIN_TWILIGHT))
+                    {
+                        libtp::tp::dzx::ACTR localGanonBarrierActor;
+                        memcpy(&localGanonBarrierActor, &GanonBarrierActor, sizeof(libtp::tp::dzx::ACTR));
 
-            tools::spawnActor(7, localGanonBarrierActor);
+                        tools::spawnActor(7, localGanonBarrierActor);
 
-            localGanonBarrierActor.pos.z -= 270.f;
-            tools::spawnActor(7, localGanonBarrierActor);
+                        localGanonBarrierActor.pos.z -= 270.f;
+                        tools::spawnActor(7, localGanonBarrierActor);
 
-            localGanonBarrierActor.pos.z -= 270.f;
-            tools::spawnActor(7, localGanonBarrierActor);
-        }
-        else if (tp::d_a_alink::checkStageName(stagesPtr[data::stage::StageIDs::Faron_Woods]) &&
-                 (tp::d_save::isEventBit(&tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags,
-                                         data::flags::ORDON_DAY_2_OVER)))
-        {
-            tools::spawnActor(6, ForestGWolfActr);
-        }
-        else if (tp::d_a_alink::checkStageName(stagesPtr[data::stage::StageIDs::Castle_Town_Shops]))
-        {
-            tools::spawnActor(6, ImpPoeActr);
-        }
-        else if (tp::d_a_alink::checkStageName(stagesPtr[data::stage::StageIDs::Bulblin_Camp]) &&
-                 !libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::ESCAPED_BURNING_TENT_IN_BULBLIN_CAMP))
-        {
-            tools::spawnActor(1, CampBoarActr);
+                        localGanonBarrierActor.pos.z -= 270.f;
+                        tools::spawnActor(7, localGanonBarrierActor);
+                    }
+                    localSignActor.pos.x = -12275.1543f;
+                    localSignActor.pos.y = -1001.9508;
+                    localSignActor.pos.z = 20293.6855f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(0, localSignActor);
+                }
+
+                if (roomIDX == 6)
+                {
+                    localSignActor.pos.x = -46039.4922f;
+                    localSignActor.pos.y = -9250.f;
+                    localSignActor.pos.z = 81859.2891f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(6, localSignActor);
+                }
+
+                if (roomIDX == 3)
+                {
+                    localSignActor.pos.x = -10906.2344f;
+                    localSignActor.pos.y = -3190.27808f;
+                    localSignActor.pos.z = 39026.707f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(3, localSignActor);
+                }
+
+                if (roomIDX == 7)
+                {
+                    localSignActor.pos.x = 29691.0742f;
+                    localSignActor.pos.y = 661.668;
+                    localSignActor.pos.z = -53367.16f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(7, localSignActor);
+                }
+
+                if (roomIDX == 10)
+                {
+                    localSignActor.pos.x = -46711.957f;
+                    localSignActor.pos.y = 268.4848f;
+                    localSignActor.pos.z = -55505.5508f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(10, localSignActor);
+                }
+
+                if (roomIDX == 13)
+                {
+                    localSignActor.pos.x = -94678.8672f;
+                    localSignActor.pos.y = -3900.f;
+                    localSignActor.pos.z = 18410.543f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(13, localSignActor);
+                }
+
+                break;
+            }
+
+            case StageIDs::Faron_Woods:
+            {
+                if (tp::d_save::isEventBit(&tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags,
+                                           data::flags::ORDON_DAY_2_OVER))
+                {
+                    tools::spawnActor(6, ForestGWolfActr);
+                }
+
+                if ((roomIDX == 8) || (roomIDX == 4))
+                {
+                    localSignActor.pos.x = -16173.2764f;
+                    localSignActor.pos.y = -348.143036f;
+                    localSignActor.pos.z = -17432.4785f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(8, localSignActor);
+                }
+                break;
+            }
+
+            case StageIDs::Castle_Town_Shops:
+            {
+                tools::spawnActor(6, ImpPoeActr);
+                break;
+            }
+
+            case StageIDs::Bulblin_Camp:
+            {
+                if (!libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::ESCAPED_BURNING_TENT_IN_BULBLIN_CAMP))
+                {
+                    tools::spawnActor(1, CampBoarActr);
+                }
+
+                localSignActor.pos.x = -2119.33057f;
+                localSignActor.pos.y = 260.f;
+                localSignActor.pos.z = -3915.6517f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(1, localSignActor);
+                break;
+            }
+
+            case StageIDs::Kakariko_Village_Interiors:
+            {
+                tools::spawnActor(3, KakShopSlot2Actr);
+                break;
+            }
+
+            case StageIDs::Kakariko_Village:
+            {
+                localSignActor.pos.x = -6277.372f;
+                localSignActor.pos.y = 2850.f;
+                localSignActor.pos.z = -2197.14331f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Ordon_Village:
+            {
+                localSignActor.pos.x = 687.89f;
+                localSignActor.pos.y = 800.f;
+                localSignActor.pos.z = -1424.16f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(1, localSignActor);
+                break;
+            }
+
+            case StageIDs::Sacred_Grove:
+            {
+                localSignActor.pos.x = -8715.3418f;
+                localSignActor.pos.y = 2000.f;
+                localSignActor.pos.z = 4178.08252f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(3, localSignActor);
+                break;
+            }
+
+            case StageIDs::Kakariko_Graveyard:
+            {
+                localSignActor.pos.x = 21765.9863f;
+                localSignActor.pos.y = 500.f;
+                localSignActor.pos.z = -62.247f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Death_Mountain:
+            {
+                localSignActor.pos.x = -5459.5757f;
+                localSignActor.pos.y = 0.f;
+                localSignActor.pos.z = -3880.2466f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Hidden_Village:
+            {
+                localSignActor.pos.x = 5161.03f;
+                localSignActor.pos.y = 0.f;
+                localSignActor.pos.z = -5264.33f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Outside_Castle_Town:
+            {
+                if (roomIDX == 8)
+                {
+                    localSignActor.pos.x = -68194.2109f;
+                    localSignActor.pos.y = -1050.f;
+                    localSignActor.pos.z = 5603.60645f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(8, localSignActor);
+                }
+                else if (roomIDX == 16)
+                {
+                    localSignActor.pos.x = -51491.0234f;
+                    localSignActor.pos.y = -5500.f;
+                    localSignActor.pos.z = 27368.3086f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                    tools::spawnActor(16, localSignActor);
+                }
+                break;
+            }
+
+            case StageIDs::Lake_Hylia_Long_Cave:
+            {
+                localSignActor.pos.x = -1006.33252f;
+                localSignActor.pos.y = -1703.19995f;
+                localSignActor.pos.z = -18715.2383f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Zoras_Domain:
+            {
+                localSignActor.pos.x = -3981.957f;
+                localSignActor.pos.y = -2500.f;
+                localSignActor.pos.z = 17230.5488f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(1, localSignActor);
+                break;
+            }
+
+            case StageIDs::Fishing_Pond:
+            {
+                localSignActor.pos.x = -2921.2417f;
+                localSignActor.pos.y = 35.f;
+                localSignActor.pos.z = 8237.2539f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Gerudo_Desert:
+            {
+                localSignActor.pos.x = 20356.23f;
+                localSignActor.pos.y = 556.7;
+                localSignActor.pos.z = 38694.8047f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Snowpeak:
+            {
+                localSignActor.pos.x = 14804.874f;
+                localSignActor.pos.y = -14450.0908f;
+                localSignActor.pos.z = -14700.9307f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Cave_of_Ordeals:
+            {
+                localSignActor.pos.x = -1191.42f;
+                localSignActor.pos.y = 1100.f;
+                localSignActor.pos.z = -260.65f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Forest_Temple:
+            {
+                localSignActor.pos.x = -2093.207f;
+                localSignActor.pos.y = 3150.f;
+                localSignActor.pos.z = 7619.086f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Goron_Mines:
+            {
+                localSignActor.pos.x = 11394.1855f;
+                localSignActor.pos.y = 2878.65;
+                localSignActor.pos.z = -17913.05f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(17, localSignActor);
+                break;
+            }
+
+            case StageIDs::Lakebed_Temple:
+            {
+                localSignActor.pos.x = -2732.113f;
+                localSignActor.pos.y = 0.f;
+                localSignActor.pos.z = -1265.67f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(3, localSignActor);
+                break;
+            }
+
+            case StageIDs::Arbiters_Grounds:
+            {
+                localSignActor.pos.x = -349.4044f;
+                localSignActor.pos.y = 450.f;
+                localSignActor.pos.z = -2568.25f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(2, localSignActor);
+                break;
+            }
+
+            case StageIDs::Snowpeak_Ruins:
+            {
+                localSignActor.pos.x = -521.855f;
+                localSignActor.pos.y = 0.f;
+                localSignActor.pos.z = -669.69f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(1, localSignActor);
+                break;
+            }
+
+            case StageIDs::Temple_of_Time:
+            {
+                localSignActor.pos.x = -618.9335f;
+                localSignActor.pos.y = 725.f;
+                localSignActor.pos.z = 3112.2f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::City_in_the_Sky:
+            {
+                localSignActor.pos.x = 3376.54f;
+                localSignActor.pos.y = 0.f;
+                localSignActor.pos.z = -12787.76f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(2, localSignActor);
+                break;
+            }
+
+            case StageIDs::Palace_of_Twilight:
+            {
+                localSignActor.pos.x = -1386.14f;
+                localSignActor.pos.y = -200.f;
+                localSignActor.pos.z = 12302.047f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(0, localSignActor);
+                break;
+            }
+
+            case StageIDs::Hyrule_Castle:
+            {
+                localSignActor.pos.x = -4.6223f;
+                localSignActor.pos.y = 25.f;
+                localSignActor.pos.z = 11607.169f;
+                localSignActor.rot[1] = static_cast<int16_t>(0xD556);
+                tools::spawnActor(11, localSignActor);
+                break;
+            }
+
+            default:
+            {
+                break;
+            }
         }
     }
 

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -127,7 +127,31 @@ namespace mod::events
         if ((strcmp(playPtr->mNextStage.stageValues.mStage, "F_SP103") == 0) && (currentRoom == 1) &&
             (currentPoint == 0x1)) // If we are spawning in Ordon for the first time.
         {
-            savePtr->save_file.player.player_status_b.skyAngle = 180.f;
+            switch (randomizer->m_Seed->m_Header->startingTimeOfDay)
+            {
+                case rando::StartingTimeOfDay::Morning:
+                {
+                    savePtr->save_file.player.player_status_b.skyAngle = 105;
+                    break;
+                }
+
+                case rando::StartingTimeOfDay::Noon:
+                {
+                    savePtr->save_file.player.player_status_b.skyAngle = 180;
+                    break;
+                }
+
+                case rando::StartingTimeOfDay::Night:
+                {
+                    savePtr->save_file.player.player_status_b.skyAngle = 0;
+                    break;
+                }
+
+                default: // Evening
+                {
+                    break;
+                }
+            }
 
             if (d_a_alink::dComIfGs_isEventBit(flags::ORDON_DAY_2_OVER))
             {

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -713,6 +713,9 @@ namespace mod::events
                 // Apply an ASM patch to d_a_Obj_Master_Sword::executeWait to give the player two items and delete the Master
                 // Sword actor instead of trying to play the purification cutscene.
                 libtp::patch::writeBranchBL(relPtrRaw + 0x254, assembly::asmGiveMasterSwordItems);
+
+                // Branch over the code that gives Link the master sword if it has been pulled
+                performStaticASMReplacement(relPtrRaw + 0xCA0, ASM_BRANCH(0x80));
                 break;
             }
         }

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -914,7 +914,7 @@ namespace mod::events
 
     int32_t proc_query042(void* unk1, void* unk2, int32_t unk3)
     {
-        if (transformAnywhereEnabled)
+        if (checkValidTransformAnywhere())
         {
             // Return false to allow transforming infront of NPCs using Midna's transform option
             return 0;
@@ -1111,6 +1111,8 @@ namespace mod::events
     void handleQuickTransform()
     {
         rando::Seed* seed;
+        using namespace libtp::data::stage;
+        using namespace libtp::tp::d_com_inf_game;
         if (seed = getCurrentSeed(randomizer), !seed)
         {
             return;
@@ -1122,7 +1124,7 @@ namespace mod::events
         }
 
         // Ensure that Link is loaded on the map.
-        libtp::tp::d_a_alink::daAlink* linkMapPtr = libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mPlayer;
+        libtp::tp::d_a_alink::daAlink* linkMapPtr = dComIfG_gameInfo.play.mPlayer;
         if (!linkMapPtr)
         {
             return;
@@ -1178,7 +1180,7 @@ namespace mod::events
             return;
         }
 
-        if (!transformAnywhereEnabled)
+        if (!checkValidTransformAnywhere())
         {
             if (daMidna_c__checkMetamorphoseEnableBase)
             {
@@ -1490,7 +1492,9 @@ namespace mod::events
 
     void* handleTransformAnywhere(libtp::tp::f_op_actor_iter::fopAcIt_JudgeFunc unk1, void* unk2)
     {
-        if (transformAnywhereEnabled)
+        using namespace libtp::data::stage;
+        using namespace libtp::tp::d_com_inf_game;
+        if (checkValidTransformAnywhere())
         {
             // Return nullptr to make the calling function return true
             return nullptr;
@@ -1498,6 +1502,39 @@ namespace mod::events
 
         // Restore the overwritten instruction
         return libtp::tp::f_op_actor_iter::fopAcIt_Judge(unk1, unk2);
+    }
+
+    bool checkValidTransformAnywhere()
+    {
+        using namespace libtp::data::stage;
+        using namespace libtp::tp::d_com_inf_game;
+
+        if (!transformAnywhereEnabled)
+        {
+            return false;
+        }
+
+        // Check if the player is currently playing the Goats minigame
+        if (libtp::tp::d_a_alink::checkStageName(allStages[StageIDs::Ordon_Ranch]))
+        {
+            switch (dComIfG_gameInfo.play.mStartStage.mLayer)
+            {
+                // Layer 4 or 5 is used when the minigame is taking place
+                case 4:
+                case 5:
+                {
+                    // Return false, as the game will crash if the player is in wolf form after the minigame ends
+                    return false;
+                }
+                default:
+                {
+                    break;
+                }
+            }
+        }
+
+        // Return true, as the bool is set and there are no conflicting scenarios to prevent transformation
+        return true;
     }
 
     KEEP_FUNC void performStaticASMReplacement(uint32_t memoryOffset, uint32_t value)

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -124,7 +124,7 @@ namespace mod::events
             randomizer->initSave();
         }
 
-        if ((strcmp(playPtr->mNextStage.stageValues.mStage, "F_SP103") == 0) && (currentRoom == 1) &&
+        if ((strcmp(playPtr->mNextStage.mStage, "F_SP103") == 0) && (currentRoom == 1) &&
             (currentPoint == 0x1)) // If we are spawning in Ordon for the first time.
         {
             switch (randomizer->m_Seed->m_Header->startingTimeOfDay)
@@ -153,7 +153,7 @@ namespace mod::events
                 }
             }
 
-            if (d_a_alink::dComIfGs_isEventBit(flags::ORDON_DAY_2_OVER))
+            if (d_com_inf_game::dComIfGs_isEventBit(flags::ORDON_DAY_2_OVER))
             {
                 savePtr->save_file.player.horse_place.mPos.y = -1000.f; // Place Epona out of bounds in Faron if Talo has been
                                                                         // rescued since the game will spawn her in the air.
@@ -837,7 +837,7 @@ namespace mod::events
 
     void setSaveFileEventFlag(uint16_t flag)
     {
-        libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags, flag);
+        libtp::tp::d_save::onEventBit(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.mEvent, flag);
     }
 
     void onAdjustFieldItemParams(libtp::tp::f_op_actor::fopAc_ac_c* fopAC, void* daObjLife)
@@ -971,7 +971,7 @@ namespace mod::events
                 libtp::data::stage::allStages[libtp::data::stage::StageIDs::Kakariko_Village_Interiors]))
         {
             // If player has not bought Barnes' Bomb Bag, we want to allow them to be able to get the check.
-            if ((!libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::BOUGHT_BARNES_BOMB_BAG)))
+            if ((!libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::BOUGHT_BARNES_BOMB_BAG)))
             {
                 return 0;
             }
@@ -1083,7 +1083,7 @@ namespace mod::events
                         for (int32_t i = 0x10; i < 0x18; i++)
                         {
                             if (libtp::tp::d_save::isDungeonItem(
-                                    &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.area_flags[i].temp_flags,
+                                    &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.mSave[i].temp_flags,
                                     3))
                             {
                                 numDungeons++;
@@ -1152,7 +1152,7 @@ namespace mod::events
         {
             case StageIDs::Lake_Hylia:
             {
-                if (libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::SKY_CANNON_REPAIRED))
+                if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::SKY_CANNON_REPAIRED))
                 {
                     // Manually spawn Auru if the Lake is in the Repaired Cannon state as his actor is not in the DZX for that
                     // layer.
@@ -1184,7 +1184,7 @@ namespace mod::events
             {
                 if (roomIDX == 0)
                 {
-                    if (!tp::d_save::isEventBit(&tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags,
+                    if (!tp::d_save::isEventBit(&tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.mEvent,
                                                 data::flags::CLEARED_ELDIN_TWILIGHT))
                     {
                         libtp::tp::dzx::ACTR localGanonBarrierActor;
@@ -1255,7 +1255,7 @@ namespace mod::events
 
             case StageIDs::Faron_Woods:
             {
-                if (tp::d_save::isEventBit(&tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.event_flags,
+                if (tp::d_save::isEventBit(&tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.mEvent,
                                            data::flags::ORDON_DAY_2_OVER))
                 {
                     tools::spawnActor(6, ForestGWolfActr);
@@ -1280,7 +1280,7 @@ namespace mod::events
 
             case StageIDs::Bulblin_Camp:
             {
-                if (!libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::ESCAPED_BURNING_TENT_IN_BULBLIN_CAMP))
+                if (!libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::ESCAPED_BURNING_TENT_IN_BULBLIN_CAMP))
                 {
                     tools::spawnActor(1, CampBoarActr);
                 }
@@ -1546,7 +1546,7 @@ namespace mod::events
     {
         using namespace libtp;
         if (tp::d_a_alink::checkStageName(data::stage::allStages[data::stage::StageIDs::Hyrule_Field]) &&
-            libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::MIDNAS_DESPERATE_HOUR_COMPLETED))
+            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::MIDNAS_DESPERATE_HOUR_COMPLETED))
         {
             tools::spawnSCOB(3, HorseJumpScob);
         }
@@ -1585,7 +1585,7 @@ namespace mod::events
         }
 
         // Check to see if Link has the ability to transform.
-        if (!libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::TRANSFORMING_UNLOCKED))
+        if (!libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::TRANSFORMING_UNLOCKED))
         {
             return;
         }
@@ -1752,7 +1752,7 @@ namespace mod::events
 
         // Check if Midna has actually been unlocked and is on the Z button
         // This is needed because the Z button will always be dimmed if she has not been unlocked
-        if (libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::MIDNA_ACCOMPANIES_WOLF))
+        if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::MIDNA_ACCOMPANIES_WOLF))
         {
             // Ensure there is a proper pointer to the mMeterClass and mpMeterDraw structs in g_meter2_info.
             if (!libtp::tp::d_meter2_info::g_meter2_info.mMeterClass)
@@ -1914,7 +1914,7 @@ namespace mod::events
         }
         else // We are not in the correct node, so use the appropriate region node
         {
-            memoryFlags = saveDataPtr->save_file.area_flags[static_cast<uint32_t>(nodeId)].temp_flags.memoryFlags;
+            memoryFlags = saveDataPtr->save_file.mSave[static_cast<uint32_t>(nodeId)].temp_flags.memoryFlags;
         }
 
         return memoryFlags;

--- a/GameCube/source/game_patch/01_getLayerNo.cpp
+++ b/GameCube/source/game_patch/01_getLayerNo.cpp
@@ -59,7 +59,7 @@ namespace mod::game_patch
                     case stage::StageIDs::Snowpeak_Ruins:
                     {
                         condition =
-                            libtp::tp::d_a_alink::dComIfGs_isEventBit(SNOWPEAK_RUINS_CLEARED); // Snowpeak Ruins Completed
+                            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(SNOWPEAK_RUINS_CLEARED); // Snowpeak Ruins Completed
 
                         if (condition)
                         {
@@ -70,7 +70,7 @@ namespace mod::game_patch
                     case stage::StageIDs::Snowpeak:
                     {
                         condition =
-                            libtp::tp::d_a_alink::dComIfGs_isEventBit(SNOWPEAK_RUINS_CLEARED); // Snowpeak Ruins Completed
+                            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(SNOWPEAK_RUINS_CLEARED); // Snowpeak Ruins Completed
 
                         if (condition && (roomId != 0))
                         {
@@ -84,7 +84,7 @@ namespace mod::game_patch
                     {
                         if ((roomId == 5) || (roomId == 6)) // North Faron or Mist Area
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
                             if (condition)
                             {
                                 chosenLayer = stage::FaronStateIDs::Faron_MDH_Completed;
@@ -96,11 +96,11 @@ namespace mod::game_patch
                         }
                         else
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
                             if (condition)
                             {
-                                condition =
-                                    libtp::tp::d_a_alink::dComIfGs_isEventBit(FOREST_TEMPLE_CLEARED); // Forest Temple Completed
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                    FOREST_TEMPLE_CLEARED); // Forest Temple Completed
 
                                 if (condition)
                                 {
@@ -117,12 +117,13 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Kakariko_Village:
                     {
-                        condition =
-                            libtp::tp::d_a_alink::dComIfGs_isEventBit(WATCHED_CUTSCENE_AFTER_GORON_MINES); // Cutscene after GM
-                                                                                                           // Watched
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                            WATCHED_CUTSCENE_AFTER_GORON_MINES); // Cutscene after GM
+                                                                 // Watched
                         if (condition == false)
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(GORON_MINES_CLEARED); // Goron Mines Completed
+                            condition =
+                                libtp::tp::d_com_inf_game::dComIfGs_isEventBit(GORON_MINES_CLEARED); // Goron Mines Completed
 
                             if (condition == false)
                             {
@@ -146,22 +147,23 @@ namespace mod::game_patch
                     }
                     case stage::StageIDs::Kakariko_Graveyard:
                     {
-                        condition =
-                            libtp::tp::d_a_alink::dComIfGs_isEventBit(GOT_ZORA_ARMOR_FROM_RUTELA); // Got Zora Armor from Rutela
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                            GOT_ZORA_ARMOR_FROM_RUTELA); // Got Zora Armor from Rutela
 
                         if (condition == false)
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ZORA_ESCORT_CLEARED); // Zora Escort Cleared
+                            condition =
+                                libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ZORA_ESCORT_CLEARED); // Zora Escort Cleared
 
                             if (condition == false)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                     WATCHED_CUTSCENE_AFTER_GORON_MINES); // Cutscene after GM
                                                                          // Watched
                                 if (condition == false)
                                 {
-                                    condition =
-                                        libtp::tp::d_a_alink::dComIfGs_isEventBit(GORON_MINES_CLEARED); // Goron Mines Completed
+                                    condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                        GORON_MINES_CLEARED); // Goron Mines Completed
 
                                     if (condition == false)
                                     {
@@ -196,8 +198,9 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Kakariko_Graveyard_Interiors:
                     {
-                        if (((roomId == 1 && (condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(LAKEBED_TEMPLE_CLEARED),
-                                              condition != false)))) // Lakebed Completed
+                        if (((roomId == 1 &&
+                              (condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(LAKEBED_TEMPLE_CLEARED),
+                               condition != false)))) // Lakebed Completed
                         {
                             chosenLayer = stage::KakarikoInteriorStateIDs::Kakariko_Int_Lakebed_Completed;
                             libtp::tp::d_com_inf_game::dComIfG_get_timelayer(&chosenLayer);
@@ -227,7 +230,8 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Death_Mountain:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(GORON_MINES_CLEARED); // Goron Mines Completed
+                        condition =
+                            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(GORON_MINES_CLEARED); // Goron Mines Completed
 
                         if (condition)
                         {
@@ -246,12 +250,12 @@ namespace mod::game_patch
                     {
                         if (roomId == 1) // Lanayru Spring
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                 LAKEBED_TEMPLE_CLEARED); // Lakebed Temple has been completed
 
                             if (condition)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                     MIDNAS_DESPERATE_HOUR_STARTED); // MDH has been started
 
                                 if (condition == false)
@@ -266,11 +270,12 @@ namespace mod::game_patch
                         }
                         else
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(SKY_CANNON_REPAIRED); // Sky Cannon Repaired
+                            condition =
+                                libtp::tp::d_com_inf_game::dComIfGs_isEventBit(SKY_CANNON_REPAIRED); // Sky Cannon Repaired
 
                             if (condition == false)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                     WARPED_SKY_CANNON_TO_LAKE_HYLIA); // Sky Cannon Warped to Lake Hylia
 
                                 if (condition == false)
@@ -292,11 +297,11 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Castle_Town_Interiors:
                     {
-                        if (condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(LAKEBED_TEMPLE_CLEARED),
+                        if (condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(LAKEBED_TEMPLE_CLEARED),
                             condition) // Lakebed Temple Completed
                         {
                             chosenLayer = stage::CastleTownInteriorsStateIDs::Castle_Town_Int_Lakebed_Completed;
-                            if (condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED),
+                            if (condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED),
                                 condition) // MDH Completed
                             {
                                 chosenLayer = stage::CastleTownInteriorsStateIDs::Castle_Town_Int_Twilight_Cleared;
@@ -311,17 +316,18 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Castle_Town:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED); // MDH Completed
+                        condition =
+                            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED); // MDH Completed
 
                         if ((condition == false))
                         {
-                            condition =
-                                libtp::tp::d_a_alink::dComIfGs_isEventBit(LAKEBED_TEMPLE_CLEARED); // Lakebed Temple Completed
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                LAKEBED_TEMPLE_CLEARED); // Lakebed Temple Completed
 
                             if (condition == false)
                             {
                                 if ((roomId == 3) &&
-                                    (condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ZORA_ESCORT_CLEARED),
+                                    (condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ZORA_ESCORT_CLEARED),
                                      condition != false)) // Zora Escort Cleared
                                 {
                                     chosenLayer = stage::CastleTownStateIDs::Castle_Town_Finished_Zora_Escort;
@@ -353,7 +359,7 @@ namespace mod::game_patch
                     case stage::StageIDs::Zoras_Domain:
                     {
                         condition =
-                            libtp::tp::d_a_alink::dComIfGs_isEventBit(SNOWPEAK_RUINS_CLEARED); // Snowpeak Ruins Completed
+                            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(SNOWPEAK_RUINS_CLEARED); // Snowpeak Ruins Completed
 
                         if (condition != false)
                         {
@@ -364,7 +370,7 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Upper_Zoras_River:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(IZA_1_MINIGAME_UNLOCKED); // Iza 1 Unlocked
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(IZA_1_MINIGAME_UNLOCKED); // Iza 1 Unlocked
                         if (condition != false)
                         {
                             chosenLayer = stage::UpperZorasRiverStateIDs::Upper_Zoras_River_Iza_1_Started;
@@ -376,8 +382,8 @@ namespace mod::game_patch
                     {
                         chosenLayer = stage::GerudoDesertStateIDs::Desert_Entrance_Cutscene_Not_Watched;
 
-                        condition =
-                            libtp::tp::d_a_alink::dComIfGs_isEventBit(VISITED_DESERT_FOR_THE_FIRST_TIME); // Have been to desert
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                            VISITED_DESERT_FOR_THE_FIRST_TIME); // Have been to desert
 
                         if (condition != false)
                         {
@@ -388,12 +394,13 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Zoras_River:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(IZA_1_MINIGAME_DONE); // Iza 1 Minigame Completed
+                        condition =
+                            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(IZA_1_MINIGAME_DONE); // Iza 1 Minigame Completed
 
                         if (condition == false)
                         {
-                            condition =
-                                libtp::tp::d_a_alink::dComIfGs_isEventBit(STARTED_IZA_1_MINIGAME); // Iza 1 Minigame Started
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                STARTED_IZA_1_MINIGAME); // Iza 1 Minigame Started
 
                             if (condition != false)
                             {
@@ -411,15 +418,16 @@ namespace mod::game_patch
                     {
                         if (roomId == 0)
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_1_FINISHED); // Ordon Day 1 done
+                            condition =
+                                libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_1_FINISHED); // Ordon Day 1 done
 
                             if (condition)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
                                 if (condition)
                                 {
-                                    condition =
-                                        libtp::tp::d_a_alink::dComIfGs_isEventBit(FINISHED_SEWERS); // First trip to Sewers done
+                                    condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                        FINISHED_SEWERS); // First trip to Sewers done
 
                                     if (condition)
                                     {
@@ -459,14 +467,15 @@ namespace mod::game_patch
                         {
                             if (roomId == 1)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_1_FINISHED); // Ordon Day 1 done
+                                condition =
+                                    libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_1_FINISHED); // Ordon Day 1 done
 
                                 if (condition)
                                 {
-                                    condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
+                                    condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
                                     if (condition)
                                     {
-                                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                             FINISHED_SEWERS); // First trip to Sewers done
 
                                         if (condition)
@@ -505,7 +514,7 @@ namespace mod::game_patch
                         /* not used in randomizer anymore. keeping for documentation sake
                         if ( roomId == 1 )     // Sera's Shop
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                 BOUGHT_SLINGSHOT_FROM_SERA );     // Bought slinghot from Sera
 
                             if ( condition )
@@ -518,8 +527,8 @@ namespace mod::game_patch
                             darkIsClear = libtp::tp::d_save::isDarkClearLV(playerStatusBPtr, 0);
                             if (darkIsClear == false)
                             {
-                                condition =
-                                    libtp::tp::d_a_alink::dComIfGs_isEventBit(FINISHED_SEWERS); // First Trip to Sewers done
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                    FINISHED_SEWERS); // First Trip to Sewers done
 
                                 if (condition != false)
                                 {
@@ -551,16 +560,16 @@ namespace mod::game_patch
                     {
                         if (roomId == 1)
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                 TALO_CHASES_MONKEY); // Sword training done on Ordon Day 2
 
                             if (condition)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo saved
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo saved
                                 if (condition)
                                 {
-                                    condition =
-                                        libtp::tp::d_a_alink::dComIfGs_isEventBit(FINISHED_SEWERS); // First trip to Sewers done
+                                    condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                        FINISHED_SEWERS); // First trip to Sewers done
 
                                     if (condition)
                                     {
@@ -594,19 +603,19 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Ordon_Ranch:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_1_FINISHED); // Day 1 done
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_1_FINISHED); // Day 1 done
                         if (condition)
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo Saved
                             if (condition)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                     WATCHED_CUTSCENE_AFTER_GOATS_2); // Saw CS after Goats 2 done
 
                                 if (condition)
                                 {
-                                    condition =
-                                        libtp::tp::d_a_alink::dComIfGs_isEventBit(FINISHED_SEWERS); // First trip to Sewers done
+                                    condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                        FINISHED_SEWERS); // First trip to Sewers done
 
                                     if (condition)
                                     {
@@ -648,13 +657,13 @@ namespace mod::game_patch
                         if (libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.player.player_status_b
                                 .dark_clear_level_flag >= 0x7)
                         {
-                            condition =
-                                libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_STARTED); // MDH State Activated
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                MIDNAS_DESPERATE_HOUR_STARTED); // MDH State Activated
 
                             if (condition)
                             {
-                                condition =
-                                    libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED); // MDH Completed
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                    MIDNAS_DESPERATE_HOUR_COMPLETED); // MDH Completed
 
                                 if (condition)
                                 {
@@ -681,12 +690,12 @@ namespace mod::game_patch
                     {
                         if (roomId == 8)
                         {
-                            condition =
-                                libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED); // MDH Completed
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
+                                MIDNAS_DESPERATE_HOUR_COMPLETED); // MDH Completed
 
                             if (condition == false)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                     MIDNAS_DESPERATE_HOUR_STARTED); // MDH State Activated
 
                                 if (condition != false)
@@ -703,21 +712,22 @@ namespace mod::game_patch
                         {
                             if (roomId == 0x10)
                             {
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(GOT_WOOD_STATUE); // Wooden Statue Gotten
+                                condition =
+                                    libtp::tp::d_com_inf_game::dComIfGs_isEventBit(GOT_WOOD_STATUE); // Wooden Statue Gotten
 
                                 if (condition == false)
                                 {
-                                    condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                    condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                         TALKED_TO_LOUISE_ABOUT_THE_STOLEN_STATUE); // Talked to Louise after Medicine Scent
 
                                     if (condition == false)
                                     {
-                                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                             MIDNAS_DESPERATE_HOUR_COMPLETED); // MDH Completed
 
                                         if (condition == false)
                                         {
-                                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                                 MIDNAS_DESPERATE_HOUR_STARTED); // MDH State Activated
 
                                             if (condition != false)
@@ -750,12 +760,12 @@ namespace mod::game_patch
                             {
                                 if (roomId == 0x11)
                                 {
-                                    condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                    condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                         MIDNAS_DESPERATE_HOUR_COMPLETED); // MDH Completed
 
                                     if (condition == false)
                                     {
-                                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                             MIDNAS_DESPERATE_HOUR_STARTED); // MDH State Activated
 
                                         if (condition != false)
@@ -775,7 +785,8 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Hidden_Village:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(GAVE_ILIA_HER_CHARM); // Ilia shown Ilia's Charm
+                        condition =
+                            libtp::tp::d_com_inf_game::dComIfGs_isEventBit(GAVE_ILIA_HER_CHARM); // Ilia shown Ilia's Charm
 
                         if (condition != false)
                         {
@@ -789,11 +800,11 @@ namespace mod::game_patch
                         if (roomId == 5)
                         {
                             chosenLayer = stage::CastleTownShopsStateIDs::Castle_Town_Int_Jovani_MDH_Completed;
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_STARTED);
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_STARTED);
                             if (condition)
                             {
                                 chosenLayer = stage::CastleTownShopsStateIDs::Castle_Town_Int_Jovani_New_Game;
-                                condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED);
+                                condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED);
                                 if (condition)
                                 {
                                     chosenLayer = stage::CastleTownShopsStateIDs::Castle_Town_Int_Jovani_MDH_Completed;
@@ -802,7 +813,7 @@ namespace mod::game_patch
                         }
                         else
                         {
-                            condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                            condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                                 MALO_MART_CASTLE_TOWN_BRANCH_IS_OPEN); // CT Shop is Malo Mart
 
                             if (condition != false)
@@ -821,7 +832,7 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Bulblin_Camp:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                             ESCAPED_BURNING_TENT_IN_BULBLIN_CAMP); // Escaped Burning Tent in Bulblin Camp
 
                         uint8_t* memoryFlagsPtr =
@@ -853,7 +864,7 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Faron_Woods_Cave:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo saved
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(ORDON_DAY_2_OVER); // Talo saved
                         if (condition != false)
                         {
                             chosenLayer = stage::FaronWoodsCaveStateIDs::Faron_Woods_Cave_Talo_Rescued;
@@ -863,7 +874,7 @@ namespace mod::game_patch
 
                     case stage::StageIDs::Hyrule_Castle_Sewers:
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(FINISHED_SEWERS); // Sewers Finished
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(FINISHED_SEWERS); // Sewers Finished
                         if (condition)
                         {
                             chosenLayer = stage::SewersStateIDs::Sewers_Midna_On_Back;
@@ -925,7 +936,7 @@ namespace mod::game_patch
         if (chosenLayer == stage::TwilightStateIDs::Default_Twilight_State)
         {
             condition =
-                libtp::tp::d_a_alink::dComIfGs_isEventBit(WARPED_METEOR_TO_ZORAS_DOMAIN); // Warped meteor to Zora's Domain
+                libtp::tp::d_com_inf_game::dComIfGs_isEventBit(WARPED_METEOR_TO_ZORAS_DOMAIN); // Warped meteor to Zora's Domain
 
             switch (stageID)
             {
@@ -955,7 +966,7 @@ namespace mod::game_patch
 
                 case stage::StageIDs::Hyrule_Castle_Sewers:
                 {
-                    condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                    condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                         WATCHED_CUTSCENE_AFTER_BEING_CAPTURED_IN_FARON_TWILIGHT); // Watched CS after being captured in
                                                                                   // Faron Twilight
                     if (condition == false)
@@ -969,7 +980,7 @@ namespace mod::game_patch
                 {
                     if (roomId == 10)
                     {
-                        condition = libtp::tp::d_a_alink::dComIfGs_isEventBit(PALACE_OF_TWILIGHT_CLEARED); // Zant Defeated
+                        condition = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(PALACE_OF_TWILIGHT_CLEARED); // Zant Defeated
 
                         if (condition == false)
                         {

--- a/GameCube/source/game_patch/02_modifyItemData.cpp
+++ b/GameCube/source/game_patch/02_modifyItemData.cpp
@@ -613,6 +613,12 @@ namespace mod::game_patch
         }
     }
 
+    KEEP_FUNC void _02_firstMirrorShardItemFunc()
+    {
+        // Update the pause menu to show the first shard.
+        events::setSaveFileEventFlag(libtp::data::flags::UPDATE_SHARDS_TO_HAVE_AT_LEAST_ARBITERS_SHARD);
+    }
+
     KEEP_FUNC void _02_secondMirrorShardItemFunc()
     {
         // Give player second mirror shard.
@@ -775,6 +781,12 @@ namespace mod::game_patch
     KEEP_FUNC int32_t _02_thirdFusedShadowItemGetCheck()
     {
         bool result = libtp::tp::d_com_inf_game::dComIfGs_isItemFirstBit(rando::customItems::Fused_Shadow_3);
+        return static_cast<int32_t>(result);
+    }
+
+    KEEP_FUNC int32_t _02_firstMirrorShardItemGetCheck()
+    {
+        bool result = libtp::tp::d_com_inf_game::dComIfGs_isItemFirstBit(rando::customItems::Mirror_Piece_1);
         return static_cast<int32_t>(result);
     }
 

--- a/GameCube/source/game_patch/02_modifyItemData.cpp
+++ b/GameCube/source/game_patch/02_modifyItemData.cpp
@@ -458,8 +458,8 @@ namespace mod::game_patch
 
     KEEP_FUNC void _02_ordonPumpkinItemFunc()
     {
-        events::setSaveFileEventFlag(libtp::data::flags::TOLD_YETA_ABOUT_PUMPKIN);               // Told Yeta about Pumpkin
-        events::setSaveFileEventFlag(libtp::data::flags::PUMPKIN_PUT_IN_SOUP);                   // Yeto put Pumpkin in soup
+        events::setSaveFileEventFlag(libtp::data::flags::TOLD_YETA_ABOUT_PUMPKIN); // Told Yeta about Pumpkin
+        events::setSaveFileEventFlag(libtp::data::flags::PUMPKIN_PUT_IN_SOUP);     // Yeto put Pumpkin in soup
 
         events::setSaveFileEventFlag(libtp::data::flags::TALKED_WITH_YETA_AFTER_GIVING_PUMPKIN); // SPR Lobby Door Unlocked
 
@@ -480,8 +480,8 @@ namespace mod::game_patch
 
     KEEP_FUNC void _02_ordonGoatCheeseItemFunc()
     {
-        events::setSaveFileEventFlag(libtp::data::flags::TOLD_YETA_ABOUT_CHEESE);               // Told Yeta about Cheese
-        events::setSaveFileEventFlag(libtp::data::flags::CHEESE_PUT_IN_SOUP);                   // Yeto put cheese in soup
+        events::setSaveFileEventFlag(libtp::data::flags::TOLD_YETA_ABOUT_CHEESE); // Told Yeta about Cheese
+        events::setSaveFileEventFlag(libtp::data::flags::CHEESE_PUT_IN_SOUP);     // Yeto put cheese in soup
 
         events::setSaveFileEventFlag(libtp::data::flags::TALKED_WITH_YETA_AFTER_GIVING_CHEESE); // SPR Lobby West Door Unlocked
 

--- a/GameCube/source/game_patch/02_modifyItemData.cpp
+++ b/GameCube/source/game_patch/02_modifyItemData.cpp
@@ -600,13 +600,13 @@ namespace mod::game_patch
             rando::Header* headerPtr = rando->m_Seed->m_Header;
 
             // If the player has the castle requirement set to Fused Shadows.
-            if (headerPtr->castleRequirements == 1)
+            if (headerPtr->castleRequirements == rando::CastleEntryRequirements::HC_Fused_Shadows)
             {
                 events::setSaveFileEventFlag(libtp::data::flags::BARRIER_GONE);
             }
 
             // If the player has the palace requirement set to Fused Shadows.
-            if (headerPtr->palaceRequirements == 1)
+            if (headerPtr->palaceRequirements == rando::PalaceEntryRequirements::PoT_Fused_Shadows)
             {
                 events::setSaveFileEventFlag(libtp::data::flags::FIXED_THE_MIRROR_OF_TWILIGHT);
             }
@@ -645,12 +645,12 @@ namespace mod::game_patch
             rando::Header* headerPtr = rando->m_Seed->m_Header;
 
             // If the player has the castle requirement set to Mirror Shards.
-            if (headerPtr->castleRequirements == 2)
+            if (headerPtr->castleRequirements == rando::CastleEntryRequirements::HC_Mirror_Shards)
             {
                 events::setSaveFileEventFlag(libtp::data::flags::BARRIER_GONE);
             }
             // If the player has the palace requirement set to Mirror Shards.
-            if (headerPtr->palaceRequirements == 2)
+            if (headerPtr->palaceRequirements == rando::PalaceEntryRequirements::PoT_Mirror_Shards)
             {
                 events::setSaveFileEventFlag(libtp::data::flags::FIXED_THE_MIRROR_OF_TWILIGHT);
             }

--- a/GameCube/source/game_patch/02_modifyItemData.cpp
+++ b/GameCube/source/game_patch/02_modifyItemData.cpp
@@ -474,7 +474,7 @@ namespace mod::game_patch
         }
         else
         {
-            savePtr->save_file.area_flags[0x14].temp_flags.memoryFlags[0x9] |= 0x4;
+            savePtr->save_file.mSave[0x14].temp_flags.memoryFlags[0x9] |= 0x4;
         }
     }
 
@@ -496,7 +496,7 @@ namespace mod::game_patch
         }
         else
         {
-            savePtr->save_file.area_flags[0x14].temp_flags.memoryFlags[0x9] |= 0x8;
+            savePtr->save_file.mSave[0x14].temp_flags.memoryFlags[0x9] |= 0x8;
         }
     }
 
@@ -567,7 +567,7 @@ namespace mod::game_patch
         else
         {
             libtp::tp::d_save::dSv_memBit_c* tempFlagsPtr =
-                &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.area_flags[0x3].temp_flags;
+                &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.mSave[0x3].temp_flags;
 
             libtp::tp::d_save::onSwitch_dSv_memBit(tempFlagsPtr, 0x69);
             libtp::tp::d_save::onSwitch_dSv_memBit(tempFlagsPtr, 0x65);

--- a/GameCube/source/game_patch/04_verifyItemFunctions.cpp
+++ b/GameCube/source/game_patch/04_verifyItemFunctions.cpp
@@ -117,8 +117,9 @@ namespace mod::game_patch
     uint32_t _04_getProgressiveMirrorShard()
     {
         using namespace libtp::data::items;
+        using namespace rando::customItems;
 
-        static const uint8_t progressiveMirrorShardsList[] {Mirror_Piece_2, Mirror_Piece_3, Mirror_Piece_4};
+        static const uint8_t progressiveMirrorShardsList[] {Mirror_Piece_1, Mirror_Piece_2, Mirror_Piece_3, Mirror_Piece_4};
 
         constexpr uint32_t listLength = sizeof(progressiveMirrorShardsList) / sizeof(progressiveMirrorShardsList[0]);
         for (uint32_t i = 0; i < listLength; i++)
@@ -268,6 +269,7 @@ namespace mod::game_patch
                     break;
                 }
 
+                case Mirror_Piece_1:
                 case Mirror_Piece_2:
                 case Mirror_Piece_3:
                 case Mirror_Piece_4:

--- a/GameCube/source/game_patch/05_itemMsgFunctions.cpp
+++ b/GameCube/source/game_patch/05_itemMsgFunctions.cpp
@@ -851,7 +851,7 @@ namespace mod::game_patch
                     *msgSizeOut = static_cast<uint16_t>(&messages[msgOffsets[i + 1]] - currentMsg);
                 }
 
-                // return currentMsg;
+                return currentMsg;
             }
         }
 

--- a/GameCube/source/game_patch/05_itemMsgFunctions.cpp
+++ b/GameCube/source/game_patch/05_itemMsgFunctions.cpp
@@ -1,7 +1,7 @@
 #include "game_patch/game_patch.h"
 #include "data/items.h"
 #include "data/stages.h"
-#include "gc_wii/bmgres.h"
+#include "tp/bmgres.h"
 #include "main.h"
 #include "tp/control.h"
 #include "tp/d_a_alink.h"

--- a/GameCube/source/game_patch/05_itemMsgFunctions.cpp
+++ b/GameCube/source/game_patch/05_itemMsgFunctions.cpp
@@ -719,7 +719,17 @@ namespace mod::game_patch
                 }
             }
 
-            const char* newMessage = getCustomMessage(msgId);
+            const char* newMessage;
+
+            if (msgId == 0x1369) // The custom message ID used for hints on custom signs
+            {
+                newMessage = _05_getSpecialMsgById(msgId);
+            }
+            else
+            {
+                newMessage = getCustomMessage(msgId);
+            }
+
             setMessageText(newMessage);
             return;
         }
@@ -866,7 +876,7 @@ namespace mod::game_patch
         using namespace rando;
 
         uint32_t hintmsgTableInfoRaw = reinterpret_cast<uint32_t>(m_HintMsgTableInfo);
-        getConsole() << msgId << " " << m_HintMsgTableInfo << " " << &m_HintMsgTableInfo << "\n";
+        // getConsole() << msgId << " " << m_HintMsgTableInfo << " " << &m_HintMsgTableInfo << "\n";
         if (!hintmsgTableInfoRaw)
         {
             return nullptr;

--- a/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
+++ b/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
@@ -51,9 +51,10 @@ namespace mod::game_patch
             }
         }
 
-        // If for some reason we find ourselves in Sacred Grove and cannot transform/warp, we want the player to be able to save
-        // warp to Faron. This is mostly usefull for Glitched Logic.
-        else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::StageIDs::Sacred_Grove]))
+        // If for some reason we find ourselves outside Sacred Grove and cannot transform/warp, we want the player to be able to
+        // save warp to Faron. This is mostly usefull for Glitched Logic.
+        else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::StageIDs::Faron_Woods]) &&
+                 (libtp::tools::getCurrentRoomNo() == 6))
         {
             if (!events::haveItem(items::Shadow_Crystal))
             {

--- a/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
+++ b/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
@@ -50,6 +50,9 @@ namespace mod::game_patch
                 playerReturnPlacePtr->link_room_id = 0x6;
             }
         }
+
+        // If for some reason we find ourselves in Sacred Grove and cannot transform/warp, we want the player to be able to save
+        // warp to Faron. This is mostly usefull for Glitched Logic.
         else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::StageIDs::Sacred_Grove]))
         {
             if (!events::haveItem(items::Shadow_Crystal))
@@ -62,7 +65,7 @@ namespace mod::game_patch
                 playerReturnPlacePtr->link_room_id = 0x6;
             }
         }
-         else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::StageIDs::Fyrus]))
+        else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[stage::StageIDs::Fyrus]))
         {
             strncpy(playerReturnPlacePtr->link_current_stage,
                     stagesPtr[stage::StageIDs::Goron_Mines],

--- a/GameCube/source/item_wheel_menu.cpp
+++ b/GameCube/source/item_wheel_menu.cpp
@@ -274,7 +274,7 @@ namespace mod::item_wheel_menu
         events::drawText(strings->pumpkin, ringPosX + pumpkinPosXOffset, ringPosY + pumpkinPosYOffset, mainTextColor, textSize);
 
         // Get the offset for the pumpkin value
-        const bool hasPumpkin = libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::TOLD_YETA_ABOUT_PUMPKIN);
+        const bool hasPumpkin = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::TOLD_YETA_ABOUT_PUMPKIN);
         uint32_t pumpkinValueOffset;
 
         if (hasPumpkin)
@@ -299,7 +299,7 @@ namespace mod::item_wheel_menu
         events::drawText(strings->cheese, ringPosX + cheesePosXOffset, ringPosY + cheesePosYOffset, mainTextColor, textSize);
 
         // Get the offset for the cheese value
-        const bool hasCheese = libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::TOLD_YETA_ABOUT_CHEESE);
+        const bool hasCheese = libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::TOLD_YETA_ABOUT_CHEESE);
         uint32_t cheeseValueOffset;
 
         if (hasCheese)

--- a/GameCube/source/item_wheel_menu.cpp
+++ b/GameCube/source/item_wheel_menu.cpp
@@ -86,6 +86,10 @@ namespace mod::item_wheel_menu
         // Hardcode false since the ring isn't being drawn anymore
         setHUDButtonsAlpha(false);
 
+        // If the item wheel is being closed, we also want to close the menu. This way, if the player forgets to close it or
+        // cannot remember how, closing the item wheel will also close the menu.
+        displayMenu = false;
+
         // dMenuRing__delete is an empty function, so don't need to call the original function
     }
 

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -72,9 +72,11 @@ namespace mod
     float prevFrameAnalogR = 0.f;
 
     KEEP_VAR uint8_t* m_MsgTableInfo = nullptr;
+    KEEP_VAR uint8_t* m_HintMsgTableInfo = nullptr;
     libtp::tp::J2DPicture::J2DPicture* bgWindow = nullptr;
     uint16_t lastButtonInput = 0;
     KEEP_VAR uint16_t m_TotalMsgEntries = 0;
+    KEEP_VAR uint16_t m_TotalHintMsgEntries = 0;
     bool roomReloadingState = false;
     bool consoleState = true;
     uint8_t gameState = GAME_BOOT;

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1518,14 +1518,41 @@ namespace mod
         libtp::tp::d_save::dSv_save_c* saveFilePtr = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file;
         if (eventPtr == &saveFilePtr->event_flags)
         {
-            libtp::tp::d_save::dSv_player_status_b_c* playerStatusPtr = &saveFilePtr->player.player_status_b;
-            const uint32_t darkClearLevelFlag = playerStatusPtr->dark_clear_level_flag;
+            libtp::tp::d_save::dSv_player_status_a_c* playerStatusAPtr = &saveFilePtr->player.player_status_a;
+            libtp::tp::d_save::dSv_player_status_b_c* playerStatusBPtr = &saveFilePtr->player.player_status_b;
+            const uint32_t darkClearLevelFlag = playerStatusBPtr->dark_clear_level_flag;
 
             switch (flag)
             {
+                // Case block for Wolf -> Human crash patches/bug fixes. Some cutscenes/events either crash or act weird if Link
+                // is Human but needs to be Wolf and the game no longer attempts to auto-transform Link once the Shadow Crystal
+                // has been obtained.
+                case ENTERED_ORDON_SPRING_DAY_3:
+                {
+                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
+                    {
+                        playerStatusAPtr->currentForm ==
+                            0; // Set player to Human as the game will not do so if Shadow Crystal has been obtained.
+                    }
+                    break;
+                }
+
+                // Case block for Human -> Wolf crash patches/bug fixes. Some cutscenes/events either crash or act weird if Link
+                // is Wolf but needs to be human and the game no longer attempts to auto-transform Link once the Shadow Crystal
+                // has been obtained.
+                case WATCHED_CUTSCENE_AFTER_BEING_CAPTURED_IN_FARON_TWILIGHT:
+                {
+                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
+                    {
+                        playerStatusAPtr->currentForm ==
+                            1; // Set player to Wolf as the game will not do so if Shadow Crystal has been obtained.
+                    }
+                    break;
+                }
+
                 case MIDNAS_DESPERATE_HOUR_COMPLETED: // MDH Completed
                 {
-                    playerStatusPtr->dark_clear_level_flag |= 0x8;
+                    playerStatusBPtr->dark_clear_level_flag |= 0x8;
                     break;
                 }
 
@@ -1535,10 +1562,10 @@ namespace mod
                     {
                         if (darkClearLevelFlag == 0x6)
                         {
-                            playerStatusPtr->transform_level_flag = 0x8; // Set the flag for the last transformed twilight.
-                                                                         // Also puts Midna on the player's back
+                            playerStatusBPtr->transform_level_flag = 0x8; // Set the flag for the last transformed twilight.
+                                                                          // Also puts Midna on the player's back
 
-                            playerStatusPtr->dark_clear_level_flag |= 0x8;
+                            playerStatusBPtr->dark_clear_level_flag |= 0x8;
                         }
                     }
                     break;
@@ -1551,10 +1578,10 @@ namespace mod
                     {
                         if (darkClearLevelFlag == 0x5)
                         {
-                            playerStatusPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed twilight.
-                                                                          // Also puts Midna on the player's back
+                            playerStatusBPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed twilight.
+                                                                           // Also puts Midna on the player's back
 
-                            playerStatusPtr->dark_clear_level_flag |= 0x8;
+                            playerStatusBPtr->dark_clear_level_flag |= 0x8;
                         }
                     }
 
@@ -1567,10 +1594,10 @@ namespace mod
                     {
                         if (darkClearLevelFlag == 0x7) // All twilights completed
                         {
-                            playerStatusPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed twilight.
-                                                                          // Also puts Midna on the player's back
+                            playerStatusBPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed twilight.
+                                                                           // Also puts Midna on the player's back
 
-                            playerStatusPtr->dark_clear_level_flag |= 0x8;
+                            playerStatusBPtr->dark_clear_level_flag |= 0x8;
                         }
                     }
 
@@ -1654,6 +1681,21 @@ namespace mod
                     libtp::tp::d_save::offSwitch_dSv_memBit(memoryBit,
                                                             0x45); // Open the Poe gate
 
+                    return;
+                }
+            }
+            else if (libtp::tp::d_a_alink::checkStageName(stagesPtr[libtp::data::stage::StageIDs::Lake_Hylia]))
+            {
+                if (flag == 0xD) // Lanayru Twilight End CS trigger.
+                {
+                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::TRANSFORMING_UNLOCKED))
+                    {
+                        libtp::tp::d_save::dSv_save_c* saveFilePtr =
+                            &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file;
+                        libtp::tp::d_save::dSv_player_status_a_c* playerStatusAPtr = &saveFilePtr->player.player_status_a;
+                        playerStatusAPtr->currentForm ==
+                            0; // Set player to Human as the game will not do so if Shadow Crystal has been obtained.
+                    }
                     return;
                 }
             }

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -256,6 +256,8 @@ namespace mod
                                        void* soundHandle,
                                        void* pos) = nullptr;
 
+    KEEP_VAR bool (*return_checkBgmIDPlaying)(libtp::z2audiolib::z2seqmgr::Z2SeqMgr* seqMgr, uint32_t sfx_id) = nullptr;
+
     // Title Screen functions
     KEEP_VAR void* (*return_dScnLogo_c_dt)(void* dScnLogo_c, int16_t bFreeThis) = nullptr;
 
@@ -268,6 +270,9 @@ namespace mod
     // d_meter functions
     KEEP_VAR void (*return_resetMiniGameItem)(libtp::tp::d_meter2_info::G_Meter2_Info* gMeter2InfoPtr,
                                               bool minigameFlag) = nullptr;
+
+    // Game Over functions
+    KEEP_VAR void (*return_dispWait_init)(libtp::tp::d_gameover::dGameOver* ptr) = nullptr;
 
     void main()
     {
@@ -1904,6 +1909,25 @@ namespace mod
     {
         z2ScenePtr = z2SceneMgr;
         return return_loadSeWave(z2SceneMgr, waveID);
+    }
+
+    KEEP_FUNC bool handle_checkBgmIDPlaying(libtp::z2audiolib::z2seqmgr::Z2SeqMgr* seqMgr, uint32_t sfx_id)
+    {
+        // Call original function immediately as it sets necessary values.
+        bool ret = return_checkBgmIDPlaying(seqMgr, sfx_id);
+
+        if (sfx_id == 0x01000013) // Game Over sfx
+        {
+            return false;
+        }
+        return ret;
+    }
+
+    KEEP_FUNC void handle_dispWait_init(libtp::tp::d_gameover::dGameOver* ptr)
+    {
+        // Set the timer
+        ptr->mTimer = 0x0;
+        return return_dispWait_init(ptr);
     }
 
     KEEP_FUNC void* handle_dScnLogo_c_dt(void* dScnLogo_c, int16_t bFreeThis)

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -819,30 +819,35 @@ namespace mod
             const uint32_t numShuffledEntrances = rando->m_Seed->m_numShuffledEntrances;
             rando::ShuffledEntrance* shuffledEntrances = &rando->m_Seed->m_ShuffledEntrances[0];
 
-            getConsole() << stageIDX << "," << roomNo << "," << point << "\n";
+            // getConsole() << stageIDX << "," << roomNo << "," << point << "\n";
 
-            for (uint32_t i = 0; i < numShuffledEntrances; i++)
+            if (stageIDX !=
+                libtp::data::stage::StageIDs::Title_Screen) // We won't want to shuffle if we are loading a save since some
+                                                            // stages use their default spawn for their entrances.
             {
-                rando::ShuffledEntrance* currentEntrance = &shuffledEntrances[i];
-                if (stageIDX == currentEntrance->origStageIDX)
+                for (uint32_t i = 0; i < numShuffledEntrances; i++)
                 {
-                    if (roomNo == currentEntrance->origRoomIDX)
+                    rando::ShuffledEntrance* currentEntrance = &shuffledEntrances[i];
+                    if (stageIDX == currentEntrance->origStageIDX)
                     {
-                        if (point == currentEntrance->origSpawn)
+                        if (roomNo == currentEntrance->origRoomIDX)
                         {
-                            getConsole() << "Shuffling Entrance"
-                                         << "\n";
-                            return return_dComIfGp_setNextStage(libtp::data::stage::allStages[currentEntrance->newStageIDX],
-                                                                currentEntrance->newSpawn,
-                                                                currentEntrance->newRoomIDX,
-                                                                layer,
-                                                                lastSpeed,
-                                                                lastMode,
-                                                                setPoint,
-                                                                wipe,
-                                                                lastAngle,
-                                                                param_9,
-                                                                wipSpeedT);
+                            if (point == currentEntrance->origSpawn)
+                            {
+                                getConsole() << "Shuffling Entrance"
+                                             << "\n";
+                                return return_dComIfGp_setNextStage(libtp::data::stage::allStages[currentEntrance->newStageIDX],
+                                                                    currentEntrance->newSpawn,
+                                                                    currentEntrance->newRoomIDX,
+                                                                    layer,
+                                                                    lastSpeed,
+                                                                    lastMode,
+                                                                    setPoint,
+                                                                    wipe,
+                                                                    lastAngle,
+                                                                    param_9,
+                                                                    wipSpeedT);
+                            }
                         }
                     }
                 }
@@ -1531,7 +1536,7 @@ namespace mod
                 {
                     if (libtp::tp::d_a_alink::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
                     {
-                        playerStatusAPtr->currentForm ==
+                        playerStatusAPtr->currentForm =
                             0; // Set player to Human as the game will not do so if Shadow Crystal has been obtained.
                     }
                     break;
@@ -1544,7 +1549,7 @@ namespace mod
                 {
                     if (libtp::tp::d_a_alink::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
                     {
-                        playerStatusAPtr->currentForm ==
+                        playerStatusAPtr->currentForm =
                             1; // Set player to Wolf as the game will not do so if Shadow Crystal has been obtained.
                     }
                     break;
@@ -1693,7 +1698,7 @@ namespace mod
                         libtp::tp::d_save::dSv_save_c* saveFilePtr =
                             &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file;
                         libtp::tp::d_save::dSv_player_status_a_c* playerStatusAPtr = &saveFilePtr->player.player_status_a;
-                        playerStatusAPtr->currentForm ==
+                        playerStatusAPtr->currentForm =
                             0; // Set player to Human as the game will not do so if Shadow Crystal has been obtained.
                     }
                     return;

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -918,7 +918,7 @@ namespace mod
             const uint32_t numShuffledEntrances = rando->m_Seed->m_numShuffledEntrances;
             rando::ShuffledEntrance* shuffledEntrances = &rando->m_Seed->m_ShuffledEntrances[0];
 
-            getConsole() << stageIDX << "," << roomNo << "," << point << "," << layer << "\n";
+            // getConsole() << stageIDX << "," << roomNo << "," << point << "," << layer << "\n";
 
             if (stageIDX !=
                 libtp::data::stage::StageIDs::Title_Screen) // We won't want to shuffle if we are loading a save since some

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -577,6 +577,9 @@ namespace mod
             // Special combo to (de)activate the console should be handled first
             if (checkBtn(currentButtons, PadInputs::Button_R | PadInputs::Button_Z))
             {
+                // Disable the input that was just pressed, as sometimes it could cause talking to Midna when in-game
+                padInfo->mPressedButtonFlags = 0;
+
                 // Disallow during boot as we print info etc.
                 // Will automatically disappear if there is no seeds to select from
                 setScreen(!consoleState);
@@ -605,6 +608,10 @@ namespace mod
             // Handle generic button checks
             if (checkButtonCombo(PadInputs::Button_R | PadInputs::Button_Y, true))
             {
+                // Disable the input that was just pressed, as sometimes it could cause items to be used or Wolf Link to dig.
+                padInfo->mPressedButtonFlags = 0;
+
+                // Handle transforming
                 events::handleQuickTransform();
             }
 
@@ -766,8 +773,10 @@ namespace mod
             switch (libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mPlayer->mProcID)
             {
                 case libtp::tp::d_a_alink::PROC_WAIT:
+                case libtp::tp::d_a_alink::PROC_TIRED_WAIT:
                 case libtp::tp::d_a_alink::PROC_MOVE:
                 case libtp::tp::d_a_alink::PROC_WOLF_WAIT:
+                case libtp::tp::d_a_alink::PROC_WOLF_TIRED_WAIT:
                 case libtp::tp::d_a_alink::PROC_WOLF_MOVE:
                 case libtp::tp::d_a_alink::PROC_SERVICE_WAIT:
                 case libtp::tp::d_a_alink::PROC_WOLF_SERVICE_WAIT:

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -918,7 +918,7 @@ namespace mod
             const uint32_t numShuffledEntrances = rando->m_Seed->m_numShuffledEntrances;
             rando::ShuffledEntrance* shuffledEntrances = &rando->m_Seed->m_ShuffledEntrances[0];
 
-            // getConsole() << stageIDX << "," << roomNo << "," << point << "\n";
+            getConsole() << stageIDX << "," << roomNo << "," << point << "," << layer << "\n";
 
             if (stageIDX !=
                 libtp::data::stage::StageIDs::Title_Screen) // We won't want to shuffle if we are loading a save since some
@@ -933,19 +933,23 @@ namespace mod
                         {
                             if (point == currentEntrance->origSpawn)
                             {
-                                getConsole() << "Shuffling Entrance"
-                                             << "\n";
-                                return return_dComIfGp_setNextStage(libtp::data::stage::allStages[currentEntrance->newStageIDX],
-                                                                    currentEntrance->newSpawn,
-                                                                    currentEntrance->newRoomIDX,
-                                                                    layer,
-                                                                    lastSpeed,
-                                                                    lastMode,
-                                                                    setPoint,
-                                                                    wipe,
-                                                                    lastAngle,
-                                                                    param_9,
-                                                                    wipSpeedT);
+                                if (layer == currentEntrance->origState)
+                                {
+                                    getConsole() << "Shuffling Entrance"
+                                                 << "\n";
+                                    return return_dComIfGp_setNextStage(
+                                        libtp::data::stage::allStages[currentEntrance->newStageIDX],
+                                        currentEntrance->newSpawn,
+                                        currentEntrance->newRoomIDX,
+                                        currentEntrance->newState,
+                                        lastSpeed,
+                                        lastMode,
+                                        setPoint,
+                                        wipe,
+                                        lastAngle,
+                                        param_9,
+                                        wipSpeedT);
+                                }
                             }
                         }
                     }

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -122,19 +122,17 @@ namespace mod
                                                  int32_t num,
                                                  void* raw_data) = nullptr;
 
-    /*
-    KEEP_VAR void ( *return_dComIfGp_setNextStage )( const char* stage,
-                                                     int16_t point,
-                                                     int8_t roomNo,
-                                                     int8_t layer,
-                                                     float lastSpeed,
-                                                     uint32_t lastMode,
-                                                     int32_t setPoint,
-                                                     int8_t wipe,
-                                                     int16_t lastAngle,
-                                                     int32_t param_9,
-                                                     int32_t wipSpeedT ) = nullptr;
-    */
+    KEEP_VAR void (*return_dComIfGp_setNextStage)(const char* stage,
+                                                  int16_t point,
+                                                  int8_t roomNo,
+                                                  int8_t layer,
+                                                  float lastSpeed,
+                                                  uint32_t lastMode,
+                                                  int32_t setPoint,
+                                                  int8_t wipe,
+                                                  int16_t lastAngle,
+                                                  int32_t param_9,
+                                                  int32_t wipSpeedT) = nullptr;
 
     // GetLayerNo trampoline
     KEEP_VAR int32_t (*return_getLayerNo_common_common)(const char* stageName, int32_t roomId, int32_t layerOverride) = nullptr;
@@ -790,40 +788,69 @@ namespace mod
         return return_tgscInfoInit(stageDt, i_data, entryNum, param_3);
     }
 
-    /*
-    KEEP_FUNC void handle_dComIfGp_setNextStage( const char* stage,
-                                                 int16_t point,
-                                                 int8_t roomNo,
-                                                 int8_t layer,
-                                                 float lastSpeed,
-                                                 uint32_t lastMode,
-                                                 int32_t setPoint,
-                                                 int8_t wipe,
-                                                 int16_t lastAngle,
-                                                 int32_t param_9,
-                                                 int32_t wipSpeedT )
+    KEEP_FUNC void handle_dComIfGp_setNextStage(const char* stage,
+                                                int16_t point,
+                                                int8_t roomNo,
+                                                int8_t layer,
+                                                float lastSpeed,
+                                                uint32_t lastMode,
+                                                int32_t setPoint,
+                                                int8_t wipe,
+                                                int16_t lastAngle,
+                                                int32_t param_9,
+                                                int32_t wipSpeedT)
     {
-        if ( libtp::tp::d_a_alink::checkStageName(
-                 libtp::data::stage::allStages[libtp::data::stage::StageIDs::Hidden_Skill] ) &&
-             ( roomNo == 6 ) )
+        rando::Randomizer* rando = randomizer;
+        if (getCurrentSeed(rando))
         {
-            // If we are in the hidden skill area and the wolf is trying to force load room 6, we know that we are trying to
-            // go back to faron so we want to use the default state instead of forcing 0.
-            layer = 0xff;
+            const int32_t stageIDX = libtp::tools::getStageIndex(stage);
+            const uint32_t numShuffledEntrances = rando->m_Seed->m_numShuffledEntrances;
+            rando::ShuffledEntrance* shuffledEntrances = &rando->m_Seed->m_ShuffledEntrances[0];
+
+            getConsole() << stageIDX << "," << roomNo << "," << point << "\n";
+
+            for (uint32_t i = 0; i < numShuffledEntrances; i++)
+            {
+                rando::ShuffledEntrance* currentEntrance = &shuffledEntrances[i];
+                if (stageIDX == currentEntrance->origStageIDX)
+                {
+                    if (roomNo == currentEntrance->origRoomIDX)
+                    {
+                        if (point == currentEntrance->origSpawn)
+                        {
+                            getConsole() << "Shuffling Entrance"
+                                         << "\n";
+                            return return_dComIfGp_setNextStage(libtp::data::stage::allStages[currentEntrance->newStageIDX],
+                                                                currentEntrance->newSpawn,
+                                                                currentEntrance->newRoomIDX,
+                                                                layer,
+                                                                lastSpeed,
+                                                                lastMode,
+                                                                setPoint,
+                                                                wipe,
+                                                                lastAngle,
+                                                                param_9,
+                                                                wipSpeedT);
+                        }
+                    }
+                }
+            }
         }
-        return return_dComIfGp_setNextStage( stage,
-                                             point,
-                                             roomNo,
-                                             layer,
-                                             lastSpeed,
-                                             lastMode,
-                                             setPoint,
-                                             wipe,
-                                             lastAngle,
-                                             param_9,
-                                             wipSpeedT );
+
+        getConsole() << "No match found."
+                     << "\n";
+        return return_dComIfGp_setNextStage(stage,
+                                            point,
+                                            roomNo,
+                                            layer,
+                                            lastSpeed,
+                                            lastMode,
+                                            setPoint,
+                                            wipe,
+                                            lastAngle,
+                                            param_9,
+                                            wipSpeedT);
     }
-    */
 
     KEEP_FUNC void handle_roomLoader(void* data, void* stageDt, int32_t roomNo)
     {

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -251,7 +251,7 @@ namespace mod
                                                  int32_t param_1,
                                                  int32_t param_2) = nullptr;
     KEEP_VAR bool (*return_checkCastleTownUseItem)(uint16_t item_id) = nullptr;
-    KEEP_VAR void (*return_procCoGetItemInit)(libtp::tp::d_a_alink::daAlink* linkActrPtr) = nullptr;
+    KEEP_VAR int32_t (*return_procCoGetItemInit)(libtp::tp::d_a_alink::daAlink* linkActrPtr) = nullptr;
 
     // Audio functions
     KEEP_VAR void (*return_loadSeWave)(void* Z2SceneMgr, uint32_t waveID) = nullptr;
@@ -521,7 +521,7 @@ namespace mod
             if (prevState != GAME_ACTIVE && state == 11)
             {
                 // check whether we're in title screen CS
-                if (0 != strcmp("S_MV000", gameInfo->play.mNextStage.stageValues.mStage))
+                if (0 != strcmp("S_MV000", gameInfo->play.mNextStage.mStage))
                 {
                     gameState = GAME_ACTIVE;
                 }
@@ -792,10 +792,10 @@ namespace mod
                             uint8_t itemToGive = 0xFF;
                             for (int i = 0; i < 4; i++)
                             {
-                                if (d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve[i] != 0)
+                                if (d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve.unk[i] != 0)
                                 {
-                                    itemToGive = d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve[i];
-                                    d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve[i] = 0x0;
+                                    itemToGive = d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve.unk[i];
+                                    d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve.unk[i] = 0x0;
                                     break;
                                 }
                             }
@@ -812,7 +812,7 @@ namespace mod
                             d_com_inf_game::dComIfG_gameInfo.play.mPlayer->mProcID = libtp::tp::d_a_alink::PROC_GET_ITEM;
 
                             //  Get the event index for the "Get Item" event.
-                            int16_t eventIdx = d_event_manager::getEventIdx(
+                            int16_t eventIdx = d_event_manager::getEventIdx3(
                                 &d_com_inf_game::dComIfG_gameInfo.play.mEvtManager,
                                 reinterpret_cast<f_op_actor::fopAc_ac_c*>(d_com_inf_game::dComIfG_gameInfo.play.mPlayer),
                                 "DEFAULT_GETITEM",
@@ -1035,7 +1035,7 @@ namespace mod
                 {
                     if (libtp::tp::d_a_alink::checkStageName(
                             libtp::data::stage::allStages[libtp::data::stage::StageIDs::Lake_Hylia]) &&
-                        !libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::CLEARED_LANAYRU_TWILIGHT))
+                        !libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::CLEARED_LANAYRU_TWILIGHT))
                     {
                         *entranceType = 0x50;
                     }
@@ -1200,7 +1200,7 @@ namespace mod
             {
                 // Check if we are at Kakariko Malo mart and verify that we have not bought the shield.
                 if (libtp::tools::playerIsInRoomStage(3, stagesPtr[StageIDs::Kakariko_Village_Interiors]) &&
-                    !tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::BOUGHT_HYLIAN_SHIELD_AT_MALO_MART))
+                    !tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::BOUGHT_HYLIAN_SHIELD_AT_MALO_MART))
                 {
                     // Return false so we can buy the shield.
                     return 0;
@@ -1254,7 +1254,7 @@ namespace mod
     KEEP_FUNC void handle_item_func_ASHS_SCRIBBLING()
     {
         using namespace libtp::data::flags;
-        if (!libtp::tp::d_a_alink::dComIfGs_isEventBit(GOT_CORAL_EARRING_FROM_RALIS))
+        if (!libtp::tp::d_com_inf_game::dComIfGs_isEventBit(GOT_CORAL_EARRING_FROM_RALIS))
         {
             return_item_func_ASHS_SCRIBBLING();
         }
@@ -1339,7 +1339,7 @@ namespace mod
     {
         const int32_t poeFlag = return_query049(unk1, unk2, unk3);
 
-        if ((poeFlag == 4) && !libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::GOT_BOTTLE_FROM_JOVANI))
+        if ((poeFlag == 4) && !libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::GOT_BOTTLE_FROM_JOVANI))
         {
             return 3;
         }
@@ -1502,6 +1502,7 @@ namespace mod
     KEEP_FUNC bool handle_isEventBit(libtp::tp::d_save::dSv_event_c* eventPtr, uint16_t flag)
     {
         using namespace libtp::tp::d_a_alink;
+        using namespace libtp::tp::d_com_inf_game;
         using namespace libtp::data::stage;
         using namespace libtp::data::flags;
 
@@ -1618,7 +1619,7 @@ namespace mod
             {
                 if (checkStageName(stagesPtr[StageIDs::Mirror_Chamber]))
                 {
-                    if (!libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::FIXED_THE_MIRROR_OF_TWILIGHT))
+                    if (!libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::FIXED_THE_MIRROR_OF_TWILIGHT))
                     {
                         using namespace libtp::data;
                         if (randoIsEnabled(rando))
@@ -1645,7 +1646,7 @@ namespace mod
             {
                 if (libtp::tools::playerIsInRoomStage(1, stagesPtr[StageIDs::Ordon_Village_Interiors]))
                 {
-                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(SERAS_CAT_RETURNED_TO_SHOP))
+                    if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(SERAS_CAT_RETURNED_TO_SHOP))
                     {
                         return false; // Return false so Sera will give the milk item to the player once they help the cat.
                     }
@@ -1673,7 +1674,7 @@ namespace mod
         using namespace libtp::data::flags;
 
         libtp::tp::d_save::dSv_save_c* saveFilePtr = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file;
-        if (eventPtr == &saveFilePtr->event_flags)
+        if (eventPtr == &saveFilePtr->mEvent)
         {
             libtp::tp::d_save::dSv_player_status_a_c* playerStatusAPtr = &saveFilePtr->player.player_status_a;
             libtp::tp::d_save::dSv_player_status_b_c* playerStatusBPtr = &saveFilePtr->player.player_status_b;
@@ -1686,7 +1687,7 @@ namespace mod
                 // has been obtained.
                 case ENTERED_ORDON_SPRING_DAY_3:
                 {
-                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
+                    if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
                     {
                         playerStatusAPtr->currentForm =
                             0; // Set player to Human as the game will not do so if Shadow Crystal has been obtained.
@@ -1699,7 +1700,7 @@ namespace mod
                 // has been obtained.
                 case WATCHED_CUTSCENE_AFTER_BEING_CAPTURED_IN_FARON_TWILIGHT:
                 {
-                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
+                    if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
                     {
                         playerStatusAPtr->currentForm =
                             1; // Set player to Wolf as the game will not do so if Shadow Crystal has been obtained.
@@ -1715,7 +1716,7 @@ namespace mod
 
                 case CLEARED_FARON_TWILIGHT: // Cleared Faron Twilight
                 {
-                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED))
+                    if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED))
                     {
                         if (darkClearLevelFlag == 0x6)
                         {
@@ -1731,7 +1732,7 @@ namespace mod
                 case CLEARED_ELDIN_TWILIGHT: // Cleared Eldin Twilight
                 {
                     events::setSaveFileEventFlag(MAP_WARPING_UNLOCKED); // in glitched Logic, you can skip the gorge bridge.
-                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED))
+                    if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED))
                     {
                         if (darkClearLevelFlag == 0x5)
                         {
@@ -1747,7 +1748,7 @@ namespace mod
 
                 case CLEARED_LANAYRU_TWILIGHT: // Cleared Lanayru Twilight
                 {
-                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED))
+                    if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(MIDNAS_DESPERATE_HOUR_COMPLETED))
                     {
                         if (darkClearLevelFlag == 0x7) // All twilights completed
                         {
@@ -1792,7 +1793,7 @@ namespace mod
         {
             if (flag == 0x66) // Check for escort completed flag
             {
-                if (!libtp::tp::d_a_alink::dComIfGs_isEventBit(
+                if (!libtp::tp::d_com_inf_game::dComIfGs_isEventBit(
                         libtp::data::flags::GOT_ZORA_ARMOR_FROM_RUTELA)) // return false if we haven't gotten the item
                                                                          // from Rutella.
                 {
@@ -1846,7 +1847,7 @@ namespace mod
             {
                 if (flag == 0xD) // Lanayru Twilight End CS trigger.
                 {
-                    if (libtp::tp::d_a_alink::dComIfGs_isEventBit(libtp::data::flags::TRANSFORMING_UNLOCKED))
+                    if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(libtp::data::flags::TRANSFORMING_UNLOCKED))
                     {
                         libtp::tp::d_save::dSv_save_c* saveFilePtr =
                             &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file;
@@ -2095,7 +2096,7 @@ namespace mod
         return return_seq_decide_yes(shopPtr, actor, msgFlow);
     }
 
-    KEEP_FUNC void handle_procCoGetItemInit(libtp::tp::d_a_alink::daAlink* linkActrPtr)
+    KEEP_FUNC int32_t handle_procCoGetItemInit(libtp::tp::d_a_alink::daAlink* linkActrPtr)
     {
         // If we are giving a custom item, we want to set mParam0 to 0x100 so that instead of trying to search for an item actor
         // that doesnt exist we want the game to create one using the item id in mGtItm.
@@ -2104,9 +2105,7 @@ namespace mod
             libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mPlayer->mDemo.mParam0 = 0x100;
             giveItemToPlayer = false;
         }
-        return_procCoGetItemInit(linkActrPtr);
-
-        return;
+        return return_procCoGetItemInit(linkActrPtr);
     }
 
     KEEP_FUNC void* handle_dScnLogo_c_dt(void* dScnLogo_c, int16_t bFreeThis)

--- a/GameCube/source/rando/randomizer.cpp
+++ b/GameCube/source/rando/randomizer.cpp
@@ -341,6 +341,25 @@ namespace mod::rando
         }
     }
 
+    int8_t Randomizer::getEventItem(uint8_t flag)
+    {
+        const uint32_t numLoadedEventChecks = m_Seed->m_numLoadedEventChecks;
+        EventItem* eventChecks = &m_Seed->m_EventChecks[0];
+
+        for (uint32_t i = 0; i < numLoadedEventChecks; i++)
+        {
+            EventItem* currentEventCheck = &eventChecks[i];
+            if (flag == currentEventCheck->flag)
+            {
+                // Return new item
+                return currentEventCheck->itemID;
+            }
+        }
+
+        // Currently we just use the vanilla item ID as the flag since the scope of these checks are limited at the moment.
+        return flag;
+    }
+
     void Randomizer::overrideARC(uint32_t fileAddr, FileDirectory fileDirectory, int32_t roomNo)
     {
         // Make sure the randomizer is loaded/enabled and a seed is loaded
@@ -661,7 +680,7 @@ namespace mod::rando
         if (rawRGBListPtr->wolfDomeAttackColor != 0xFFFFFFFF) // Don't do anything if the value is default
         {
             uint8_t* domeRGBA = reinterpret_cast<uint8_t*>(&rawRGBListPtr->wolfDomeAttackColor);
-            uint8_t** chromaRegisterTable = reinterpret_cast<uint8_t**>(&linkActrPtr->tevRegKey->chromaRPtr);
+            uint8_t** chromaRegisterTable = reinterpret_cast<uint8_t**>(&linkActrPtr->field_0x0724->chromaRPtr);
 
             for (uint32_t i = 0; i < 3; i++)
             {
@@ -676,5 +695,19 @@ namespace mod::rando
                 currentTable[0x2B] = currentColor; // Set Alpha for darkworld ring wave 2
             }
         }
+    }
+
+    void Randomizer::addItemToEventQueue(uint8_t itemToAdd)
+    {
+        using namespace libtp::tp;
+        for (int i = 0; i < 4; i++)
+        {
+            if (d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve[i] == 0)
+            {
+                d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve[i] = itemToAdd;
+                break;
+            }
+        }
+        return;
     }
 } // namespace mod::rando

--- a/GameCube/source/rando/randomizer.cpp
+++ b/GameCube/source/rando/randomizer.cpp
@@ -69,7 +69,7 @@ namespace mod::rando
             return;
         }
 
-        const char* stage = libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mNextStage.stageValues.mStage;
+        const char* stage = libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mNextStage.mStage;
         seed->LoadChecks(stage);
 
         // Make sure the foolish items spawn count is reset before randomizing foolish item models
@@ -680,7 +680,7 @@ namespace mod::rando
         if (rawRGBListPtr->wolfDomeAttackColor != 0xFFFFFFFF) // Don't do anything if the value is default
         {
             uint8_t* domeRGBA = reinterpret_cast<uint8_t*>(&rawRGBListPtr->wolfDomeAttackColor);
-            uint8_t** chromaRegisterTable = reinterpret_cast<uint8_t**>(&linkActrPtr->field_0x0724->chromaRPtr);
+            uint8_t** chromaRegisterTable = reinterpret_cast<uint8_t**>(&linkActrPtr->tevRegKey->chromaRPtr);
 
             for (uint32_t i = 0; i < 3; i++)
             {
@@ -702,9 +702,9 @@ namespace mod::rando
         using namespace libtp::tp;
         for (int i = 0; i < 4; i++)
         {
-            if (d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve[i] == 0)
+            if (d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve.unk[i] == 0)
             {
-                d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve[i] = itemToAdd;
+                d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve.unk[i] = itemToAdd;
                 break;
             }
         }

--- a/GameCube/source/rando/seed.cpp
+++ b/GameCube/source/rando/seed.cpp
@@ -74,7 +74,7 @@ namespace mod::rando
                 const uint32_t offset = eventFlags[i].offset;
                 const uint8_t flag = eventFlags[i].flag;
 
-                gameInfo->save.save_file.event_flags.event_flags[offset] |= flag;
+                gameInfo->save.save_file.mEvent.mEvent[offset] |= flag;
                 eventFlagsModified++;
             }
 

--- a/GameCube/source/rando/seed.cpp
+++ b/GameCube/source/rando/seed.cpp
@@ -188,6 +188,7 @@ namespace mod::rando
             this->LoadBugReward();
             this->LoadSkyCharacter(stageIDX);
             this->LoadHiddenSkill();
+            this->LoadEventChecks(stageIDX);
 
             // Save current stageIDX for next time
             this->m_StageIDX = stageIDX;
@@ -204,6 +205,7 @@ namespace mod::rando
         m_numBugRewardChecks = 0;
         m_numSkyBookChecks = 0;
         m_numHiddenSkillChecks = 0;
+        m_numLoadedEventChecks = 0;
 
         delete[] m_DZXChecks;
         delete[] m_RELChecks;
@@ -212,6 +214,7 @@ namespace mod::rando
         delete[] m_BugRewardChecks;
         delete[] m_SkyBookChecks;
         delete[] m_HiddenSkillChecks;
+        delete[] m_EventChecks;
     }
 
     void Seed::LoadDZX(uint8_t stageIDX)
@@ -466,6 +469,39 @@ namespace mod::rando
                 memcpy(bossChecksPtr, currentBossCheck, sizeof(BossCheck));
                 break;
             }
+        }
+    }
+
+    void Seed::LoadEventChecks(uint8_t stageIDX)
+    {
+        using namespace libtp;
+
+        Header* headerPtr = m_Header;
+        const uint32_t num_eventchecks = headerPtr->eventItemCheckInfo.numEntries;
+        const uint32_t gci_offset = headerPtr->eventItemCheckInfo.dataOffset;
+
+        // Set the pointer as offset into our buffer
+        EventItem* eventChecksPtr = new EventItem[num_eventchecks];
+        m_EventChecks = eventChecksPtr;
+        EventItem* allEvent = reinterpret_cast<EventItem*>(&m_GCIData[gci_offset]);
+
+        // offset into m_SkyBookChecks
+        uint32_t j = 0;
+
+        for (uint32_t i = 0; i < num_eventchecks; i++)
+        {
+            EventItem* currentEventCheck = &allEvent[i];
+            EventItem* globalEventCheck = &eventChecksPtr[j];
+
+            uint32_t numEventChecks = m_numLoadedEventChecks;
+            if ((currentEventCheck->stageIDX == stageIDX))
+            {
+                getConsole() << "we have a check\n";
+                memcpy(globalEventCheck, currentEventCheck, sizeof(EventItem));
+                numEventChecks++;
+                j++;
+            }
+            m_numLoadedEventChecks = static_cast<uint16_t>(numEventChecks);
         }
     }
 

--- a/GameCube/source/rando/seed.cpp
+++ b/GameCube/source/rando/seed.cpp
@@ -496,7 +496,6 @@ namespace mod::rando
             uint32_t numEventChecks = m_numLoadedEventChecks;
             if ((currentEventCheck->stageIDX == stageIDX))
             {
-                getConsole() << "we have a check\n";
                 memcpy(globalEventCheck, currentEventCheck, sizeof(EventItem));
                 numEventChecks++;
                 j++;

--- a/GameCube/subrel/boot/source/custom_messages/englishMessages.cpp
+++ b/GameCube/subrel/boot/source/custom_messages/englishMessages.cpp
@@ -152,6 +152,18 @@ namespace mod::customMessages
         MSG_COLOR(MSG_COLOR_WHITE)
         " and\nsmells like fish.."
     MSG_END();
+    MSG_BEGIN_ARRAY( firstMirrorShardEn )
+        MSG_SPEED(MSG_SPEED_FAST)
+        "You got the first shard of\nthe "
+        MSG_COLOR(MSG_COLOR_RED)
+        "Mirror of Twilight"
+        MSG_COLOR(MSG_COLOR_WHITE)
+        "! It\nis covered in "
+        MSG_COLOR(MSG_COLOR_ORANGE)
+        "sand"
+        MSG_COLOR(MSG_COLOR_WHITE)
+        ".."
+    MSG_END();
     MSG_BEGIN_ARRAY( secondMirrorShardEn )
         MSG_SPEED(MSG_SPEED_FAST)
         "You got the second shard of\nthe "
@@ -366,6 +378,11 @@ namespace mod::customMessages
         thirdFusedShadowEn,
         sizeof(thirdFusedShadowEn),
         0x013E,
+
+        // First Mirror Shard
+        firstMirrorShardEn,
+        sizeof(firstMirrorShardEn),
+        0x0B7,
 
         // Second Mirror Shard
         secondMirrorShardEn,

--- a/GameCube/subrel/boot/source/game_patch/02_modifyItemData.cpp
+++ b/GameCube/subrel/boot/source/game_patch/02_modifyItemData.cpp
@@ -165,6 +165,7 @@ namespace mod::game_patch
                                                     libtp::data::items::Key_Shard_3,
                                                     libtp::data::items::Big_Key_Goron_Mines,
                                                     libtp::data::items::Coro_Key,
+                                                    rando::customItems::Mirror_Piece_1,
                                                     libtp::data::items::Mirror_Piece_2,
                                                     libtp::data::items::Mirror_Piece_3,
                                                     libtp::data::items::Mirror_Piece_4,
@@ -320,6 +321,7 @@ namespace mod::game_patch
                                                customItems::Ancient_Sky_Book_Fifth_Character};
 
         uint8_t customShardsIDs[] = {
+            customItems::Mirror_Piece_1,
             items::Mirror_Piece_2,
             items::Mirror_Piece_3,
             items::Mirror_Piece_4,
@@ -486,6 +488,7 @@ namespace mod::game_patch
         itemFuncPtr[customItems::Fused_Shadow_1] = _02_firstFusedShadowItemFunc;
         itemFuncPtr[customItems::Fused_Shadow_2] = _02_secondFusedShadowItemFunc;
         itemFuncPtr[customItems::Fused_Shadow_3] = _02_thirdFusedShadowItemFunc;
+        itemFuncPtr[customItems::Mirror_Piece_1] = _02_firstMirrorShardItemFunc;
         itemFuncPtr[items::Mirror_Piece_2] = _02_secondMirrorShardItemFunc;
         itemFuncPtr[items::Mirror_Piece_3] = _02_thirdMirrorShardItemFunc;
         itemFuncPtr[items::Mirror_Piece_4] = _02_fourthMirrorShardItemFunc;
@@ -528,6 +531,7 @@ namespace mod::game_patch
         itemGetCheckFuncPtr[customItems::Fused_Shadow_1] = _02_firstFusedShadowItemGetCheck;
         itemGetCheckFuncPtr[customItems::Fused_Shadow_2] = _02_secondFusedShadowItemGetCheck;
         itemGetCheckFuncPtr[customItems::Fused_Shadow_3] = _02_thirdFusedShadowItemGetCheck;
+        itemGetCheckFuncPtr[customItems::Mirror_Piece_1] = _02_firstMirrorShardItemGetCheck;
         itemGetCheckFuncPtr[items::Mirror_Piece_2] = _02_secondMirrorShardItemGetCheck;
         itemGetCheckFuncPtr[items::Mirror_Piece_3] = _02_thirdMirrorShardItemGetCheck;
         itemGetCheckFuncPtr[items::Mirror_Piece_4] = _02_fourthMirrorShardItemGetCheck;

--- a/GameCube/subrel/boot/source/game_patch/06_asmOverrides.cpp
+++ b/GameCube/subrel/boot/source/game_patch/06_asmOverrides.cpp
@@ -44,12 +44,6 @@ namespace mod::game_patch
         // Nop out the instruction that causes a miscalculation in message resources.
         *patchMessageCalculation = ASM_NOP;
 
-        // Modify the skipper function to check whether or not a cutscene is skippable instead of whether the player skips the
-        // CS. This effectively auto-skips all skippable cutscenes.
-        uint32_t skipperFunctionAddress = reinterpret_cast<uint32_t>(libtp::tp::d_event::skipper);
-        *reinterpret_cast<uint32_t*>(skipperFunctionAddress + 0x54) =
-            ASM_COMPARE_LOGICAL_WORD_IMMEDIATE(30, 0); // Previous rlwinm r0,r0,0,19,19
-
         // Modify the Wooden Sword function to not set a region flag by default by nopping out the function call to isSwitch
         uint32_t woodenSwordFunctionAddress = reinterpret_cast<uint32_t>(libtp::tp::d_item::item_func_WOOD_STICK);
         *reinterpret_cast<uint32_t*>(woodenSwordFunctionAddress + 0x40) = ASM_NOP; // Previous 0x4bf9cafd

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -120,10 +120,8 @@ namespace mod
         // return_stageLoader = patch::hookFunction( libtp::tp::d_stage::stageLoader, mod::handle_stageLoader );
         return_dStage_playerInit = patch::hookFunction(libtp::tp::d_stage::dStage_playerInit, mod::handle_dStage_playerInit);
 
-        /*
         return_dComIfGp_setNextStage =
-            patch::hookFunction( libtp::tp::d_com_inf_game::dComIfGp_setNextStage, mod::handle_dComIfGp_setNextStage );
-        */
+            patch::hookFunction(libtp::tp::d_com_inf_game::dComIfGp_setNextStage, mod::handle_dComIfGp_setNextStage);
 
         // Custom States
         return_getLayerNo_common_common = patch::hookFunction(getLayerNo_common_common, game_patch::_01_getLayerNo);

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -184,6 +184,8 @@ namespace mod
         return_query042 = patch::hookFunction(libtp::tp::d_msg_flow::query042, mod::handle_query042);
         // return_event000 = patch::hookFunction( libtp::tp::d_msg_flow::event000, mod::handle_event000 );
         return_event017 = patch::hookFunction(libtp::tp::d_msg_flow::event017, mod::handle_event017);
+        return_doFlow = patch::hookFunction(libtp::tp::d_msg_flow::doFlow, mod::handle_doFlow);
+        return_setNormalMsg = patch::hookFunction(libtp::tp::d_msg_flow::setNormalMsg, mod::handle_setNormalMsg);
 
         // Save flag functions
         return_isDungeonItem = patch::hookFunction(tp::d_save::isDungeonItem, mod::handle_isDungeonItem);
@@ -258,6 +260,9 @@ namespace mod
 
         // Game Over functions
         return_dispWait_init = patch::hookFunction(libtp::tp::d_gameover::dispWait_init, mod::handle_dispWait_init);
+
+        // Shop Functions
+        return_seq_decide_yes = patch::hookFunction(libtp::tp::d_shop_system::seq_decide_yes, mod::handle_seq_decide_yes);
     }
 
     void initRandState()

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -234,6 +234,8 @@ namespace mod
         return_damageMagnification =
             patch::hookFunction(libtp::tp::d_a_alink::damageMagnification, mod::handle_damageMagnification);
 
+        return_procCoGetItemInit = patch::hookFunction(libtp::tp::d_a_alink::procCoGetItemInit, mod::handle_procCoGetItemInit);
+
         // Audio functions
         return_loadSeWave = patch::hookFunction(libtp::z2audiolib::z2scenemgr::loadSeWave, mod::handle_loadSeWave);
         return_sceneChange = patch::hookFunction(libtp::z2audiolib::z2scenemgr::sceneChange, mod::handle_sceneChange);

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -236,6 +236,8 @@ namespace mod
         return_loadSeWave = patch::hookFunction(libtp::z2audiolib::z2scenemgr::loadSeWave, mod::handle_loadSeWave);
         return_sceneChange = patch::hookFunction(libtp::z2audiolib::z2scenemgr::sceneChange, mod::handle_sceneChange);
         return_startSound = patch::hookFunction(libtp::z2audiolib::z2soundmgr::startSound, mod::handle_startSound);
+        return_checkBgmIDPlaying =
+            patch::hookFunction(libtp::z2audiolib::z2seqmgr::checkBgmIDPlaying, mod::handle_checkBgmIDPlaying);
 
         // Title Screen functions
         return_dScnLogo_c_dt = patch::hookFunction(libtp::tp::d_s_logo::dScnLogo_c_dt, mod::handle_dScnLogo_c_dt);
@@ -253,6 +255,9 @@ namespace mod
         // d_meter functions
         return_resetMiniGameItem =
             patch::hookFunction(libtp::tp::d_meter2_info::resetMiniGameItem, mod::handle_resetMiniGameItem);
+
+        // Game Over functions
+        return_dispWait_init = patch::hookFunction(libtp::tp::d_gameover::dispWait_init, mod::handle_dispWait_init);
     }
 
     void initRandState()

--- a/GameCube/subrel/seed/source/rando/randomizer.cpp
+++ b/GameCube/subrel/seed/source/rando/randomizer.cpp
@@ -50,6 +50,8 @@ namespace mod::rando
                 // Update transformAnywhereEnabled now that a seed is loaded
                 transformAnywhereEnabled = static_cast<bool>(m_Seed->m_Header->transformAnywhere);
 
+                m_Seed->loadShuffledEntrances();
+
                 // Load checks for first load
                 onStageLoad();
             }

--- a/GameCube/subrel/seed/source/rando/seed.cpp
+++ b/GameCube/subrel/seed/source/rando/seed.cpp
@@ -91,7 +91,7 @@ namespace mod::rando
             // Load the custom text data
             this->loadCustomText(data);
 
-            // Set the static pointers for the Seed Header and Data
+            // Set the static pointers for the Seed Header and Data. These are used by TPO
             void** ptrTable = reinterpret_cast<void**>(0x800042BC);
             ptrTable[0] = m_Header;
             ptrTable[1] = m_GCIData;
@@ -104,7 +104,7 @@ namespace mod::rando
         // Make sure to delete tempcheck buffers
         this->clearChecks();
 
-        // Clear the static pointers for the Seed Header and Data
+        // Clear the static pointers for the Seed Header and Data.  These are used by TPO
         void** ptrTable = reinterpret_cast<void**>(0x800042BC);
         ptrTable[0] = nullptr;
         ptrTable[1] = nullptr;

--- a/GameCube/subrel/seed/source/rando/seed.cpp
+++ b/GameCube/subrel/seed/source/rando/seed.cpp
@@ -211,10 +211,6 @@ namespace mod::rando
         // Set the pointer as offset into our buffer
         m_ShuffledEntrances = reinterpret_cast<ShuffledEntrance*>(&m_GCIData[gci_offset]);
         m_numShuffledEntrances = num_shuffledEntrances;
-
-        getConsole() << reinterpret_cast<uint32_t>(m_ShuffledEntrances) << "\n";
-        getConsole() << reinterpret_cast<uint32_t>(m_GCIData) << "\n";
-        getConsole() << reinterpret_cast<uint32_t>(num_shuffledEntrances) << "\n";
     }
     bool Seed::loadCustomText(uint8_t* data)
     {
@@ -242,8 +238,6 @@ namespace mod::rando
 
             // Copy the data to the pointers
             memcpy(m_HintMsgTableInfo, &data[offset], msgTableInfoSize);
-            getConsole() << &m_HintMsgTableInfo << " " << headerOffset << " " << customMessageHeader->msgIdTableOffset << " "
-                         << msgTableInfoSize << "\n";
             return true;
         }
 

--- a/GameCube/subrel/seed/source/rando/seed.cpp
+++ b/GameCube/subrel/seed/source/rando/seed.cpp
@@ -226,24 +226,23 @@ namespace mod::rando
 
             // Get the text for the current language
             // US/JP should only have one language included
-            CustomMessageEntryInfo* customMessageInfo = &customMessageHeader->entry[0];
 
             // Allocate memory for the ids, message offsets, and messages
-            m_TotalHintMsgEntries = customMessageInfo->totalEntries;
+            m_TotalHintMsgEntries = customMessageHeader->totalEntries;
             uint32_t msgIdTableSize = m_TotalHintMsgEntries * sizeof(CustomMessageData);
             uint32_t msgOffsetTableSize = m_TotalHintMsgEntries * sizeof(uint32_t);
             // Round msgIdTableSize up to the size of the offsets to make sure the offsets are properly aligned
             msgIdTableSize = (msgIdTableSize + sizeof(uint32_t) - 1) & ~(sizeof(uint32_t) - 1);
-            uint32_t msgTableInfoSize = msgIdTableSize + msgOffsetTableSize + customMessageInfo->msgTableSize;
+            uint32_t msgTableInfoSize = msgIdTableSize + msgOffsetTableSize + customMessageHeader->msgTableSize;
 
             m_HintMsgTableInfo = new uint8_t[msgTableInfoSize];
             // When calculating the offset the the message table information, we are assuming that the message header is
             // followed by the entry information for all of the languages in the seed data.
-            uint32_t offset = headerOffset + customMessageInfo->msgIdTableOffset;
+            uint32_t offset = headerOffset + customMessageHeader->msgIdTableOffset;
 
             // Copy the data to the pointers
             memcpy(m_HintMsgTableInfo, &data[offset], msgTableInfoSize);
-            getConsole() << &m_HintMsgTableInfo << " " << headerOffset << " " << customMessageInfo->msgIdTableOffset << " "
+            getConsole() << &m_HintMsgTableInfo << " " << headerOffset << " " << customMessageHeader->msgIdTableOffset << " "
                          << msgTableInfoSize << "\n";
             return true;
         }

--- a/GameCube/subrel/seed/source/rando/seed.cpp
+++ b/GameCube/subrel/seed/source/rando/seed.cpp
@@ -195,4 +195,22 @@ namespace mod::rando
             m_FanfareTable = reinterpret_cast<BGMReplacement*>(buf);
         }
     }
+
+    void Seed::loadShuffledEntrances()
+    {
+        using namespace libtp::tp;
+        using namespace libtp::data;
+
+        entryInfo* shuffledEntranceInfo = &m_Header->EntranceTableInfo;
+        const uint32_t num_shuffledEntrances = shuffledEntranceInfo->numEntries;
+        const uint32_t gci_offset = shuffledEntranceInfo->dataOffset;
+
+        // Set the pointer as offset into our buffer
+        m_ShuffledEntrances = reinterpret_cast<ShuffledEntrance*>(&m_GCIData[gci_offset]);
+        m_numShuffledEntrances = num_shuffledEntrances;
+
+        getConsole() << reinterpret_cast<uint32_t>(m_ShuffledEntrances) << "\n";
+        getConsole() << reinterpret_cast<uint32_t>(m_GCIData) << "\n";
+        getConsole() << reinterpret_cast<uint32_t>(num_shuffledEntrances) << "\n";
+    }
 } // namespace mod::rando

--- a/GameCube/subrel/seed/source/user_patch/05_newFileFunctions.cpp
+++ b/GameCube/subrel/seed/source/user_patch/05_newFileFunctions.cpp
@@ -22,4 +22,20 @@ namespace mod::user_patch
         (void)randomizer;
         increaseSpinnerSpeed = set;
     }
+
+    void skipMajorCutscenes(rando::Randomizer* randomizer, bool set)
+    {
+        (void)randomizer;
+        uint32_t skipperFunctionAddress = reinterpret_cast<uint32_t>(libtp::tp::d_event::skipper);
+        if (set)
+        {
+            // Modifies the 'skipper' function to automatically attempt to skip all major cutscenes
+            *reinterpret_cast<uint32_t*>(skipperFunctionAddress + 0x54) = 0x281e0000; // cmplwi r30, 0
+        }
+        else
+        {
+            // Vanilla instruction
+            *reinterpret_cast<uint32_t*>(skipperFunctionAddress + 0x54) = 540004e7; // rlwinm r0,r0,0,19,19
+        }
+    }
 } // namespace mod::user_patch

--- a/GameCube/subrel/seed/source/user_patch/05_newFileFunctions.cpp
+++ b/GameCube/subrel/seed/source/user_patch/05_newFileFunctions.cpp
@@ -2,6 +2,7 @@
 #include "rando/data.h"
 #include "rando/randomizer.h"
 #include "user_patch/user_patch.h"
+#include "memory.h"
 
 namespace mod::user_patch
 {
@@ -26,16 +27,18 @@ namespace mod::user_patch
     void skipMajorCutscenes(rando::Randomizer* randomizer, bool set)
     {
         (void)randomizer;
-        uint32_t skipperFunctionAddress = reinterpret_cast<uint32_t>(libtp::tp::d_event::skipper);
+        uint32_t* skipperFunctionAddress =
+            reinterpret_cast<uint32_t*>(reinterpret_cast<uint32_t>(libtp::tp::d_event::skipper) + 0x54);
         if (set)
         {
             // Modifies the 'skipper' function to automatically attempt to skip all major cutscenes
-            *reinterpret_cast<uint32_t*>(skipperFunctionAddress + 0x54) = 0x281e0000; // cmplwi r30, 0
+            *skipperFunctionAddress = 0x281e0000; // cmplwi r30, 0
         }
         else
         {
             // Vanilla instruction
-            *reinterpret_cast<uint32_t*>(skipperFunctionAddress + 0x54) = 540004e7; // rlwinm r0,r0,0,19,19
+            *skipperFunctionAddress = 0x540004e7; // rlwinm r0,r0,0,19,19
         }
+        libtp::memory::clear_DC_IC_Cache(skipperFunctionAddress, sizeof(uint32_t));
     }
 } // namespace mod::user_patch

--- a/GameCube/subrel/seed/source/user_patch/user_patch.cpp
+++ b/GameCube/subrel/seed/source/user_patch/user_patch.cpp
@@ -14,6 +14,11 @@
 
 namespace mod::user_patch
 {
-    GamePatch oneTimePatches[6] =
-        {patchWallet, removeIBLimit, loadShopModels, disableBattleMusic, setInstantText, increaseSpinnerVelocity};
+    GamePatch oneTimePatches[7] = {patchWallet,
+                                   removeIBLimit,
+                                   loadShopModels,
+                                   disableBattleMusic,
+                                   setInstantText,
+                                   increaseSpinnerVelocity,
+                                   skipMajorCutscenes};
 }


### PR DESCRIPTION
- Added support for Entrance Randomization based on data stored in a seed file
- Added support for reading text that is stored in a seed file
- Patched improper form crashes and added support for a new setting called "Skip Major Cutscenes" so players can choose to skip all cutscenes.
- Added code to reduce the amount of time it takes for the Game Over cutscene to complete. 
- Added code to close the key counter menu if the item wheel is closed.
- Added code to support randomizing more shop items
- Created framework to be able to give the player an item at any time.
- Added support for two checks to be given when the player picks up the Master Sword in Sacred Grove
- Added support for starting time of day
- Started to add support for custom sign actors to be used for hints. 
-- Don't talk to the DMT sign or you will softlock at the time of this commit. tyty